### PR TITLE
Fix secret key name references in StatefulSet

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 1.1.1
+version: 1.1.2
 appVersion: 3.0.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - name: "POSTGRESQL_PASS"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-postgresql-pass"
+              name: "{{ template "zammad.fullname" . }}-postgresql-pass"
               key: "postgresql-pass"
         - name: "POSTGRESQL_DB"
           value: "{{ .Values.envConfig.postgresql.db }}"
@@ -174,7 +174,7 @@ spec:
         - name: "POSTGRESQL_PASS"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-postgresql-pass"
+              name: "{{ template "zammad.fullname" . }}-postgresql-pass"
               key: "postgresql-pass"
         - name: "POSTGRESQL_DB"
           value: "{{ .Values.envConfig.postgresql.db }}"
@@ -218,7 +218,7 @@ spec:
         - name: "POSTGRESQL_PASS"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-postgresql-pass"
+              name: "{{ template "zammad.fullname" . }}-postgresql-pass"
               key: "postgresql-pass"
         - name: "POSTGRESQL_DB"
           value: "{{ .Values.envConfig.postgresql.db }}"

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
         - name: "AUTOWIZARD_JSON"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-autowizard"
+              name: "{{ template "zammad.fullname" . }}-autowizard"
               key: "autowizard"
         {{ end }}
         {{- range $key, $value := .Values.extraEnv }}
@@ -94,7 +94,7 @@ spec:
         - name: "AUTOWIZARD_JSON"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-autowizard"
+              name: "{{ template "zammad.fullname" . }}-autowizard"
               key: "autowizard"
         {{ end }}
         {{- range $key, $value := .Values.extraEnv }}
@@ -184,7 +184,7 @@ spec:
         - name: "AUTOWIZARD_JSON"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-autowizard"
+              name: "{{ template "zammad.fullname" . }}-autowizard"
               key: "autowizard"
         {{ end }}
         {{- range $key, $value := .Values.extraEnv }}
@@ -228,7 +228,7 @@ spec:
         - name: "AUTOWIZARD_JSON"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-autowizard"
+              name: "{{ template "zammad.fullname" . }}-autowizard"
               key: "autowizard"
         {{ end }}
         {{- range $key, $value := .Values.extraEnv }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the secret key name references for the PostgreSQL password as well as the autowizard JSON. One instance of the secret key reference was already using the correct name (see line 87 in the `statefulset.yaml` which I didn't touch).