### PR TITLE
Add ability to use volume claim templates in Zammad StatefulSet

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 1.1.2
+version: 1.1.3
 appVersion: 3.0.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -58,6 +58,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `persistence.enabled`                              | Enable persistence                               | `true`                          |
 | `persistence.accessMode`                           | Access mode                                      | `ReadWriteOnce`                 |
 | `persistence.size`                                 | Volume size                                      | `15Gi`                          |
+| `persistence.volumeClaimTemplates`                 | Volume claim templates                           | ``                              |
 | `resources.nginx`                                  | Resource usage of Zammad's nginx container       | `{}`                            |
 | `resources.railsserver`                            | Resource usage of Zammad's railsserver container | `{}`                            |
 | `resources.scheduler`                              | Resource usage of Zammad's scheduler container   | `{}`                            |

--- a/zammad/templates/pvc.yaml
+++ b/zammad/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (not .Values.persistence.volumeClaimTemplates)  }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -270,10 +270,15 @@ spec:
       - name: {{ template "zammad.fullname" . }}-nginx
         configMap:
           name: {{ template "zammad.fullname" . }}-nginx
+      {{- if not .Values.persistence.enabled }}
       - name: {{ template "zammad.fullname" . }}
-      {{- if .Values.persistence.enabled }}
+        emptyDir: {}
+      {{ else if not .Values.persistence.volumeClaimTemplates }}
+      - name: {{ template "zammad.fullname" . }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "zammad.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
       {{- end -}}
+{{- if and .Values.persistence.enabled .Values.persistence.volumeClaimTemplates }}
+  volumeClaimTemplates:
+{{ toYaml .Values.persistence.volumeClaimTemplates | indent 4 }}
+{{- end -}}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -108,6 +108,19 @@ persistence:
   accessMode: ReadWriteOnce
   size: 15Gi
 
+  ## Use volume claim templates instead for greater customizability (don't mix with the properties above):
+  # volumeClaimTemplates:
+  #   - metadata:
+  #       # when using helm template to generate manifests, the name to use is the value of `--name` parameter + "-zammad" suffix
+  #       # e.g. when using `helm template --name example-support-center -f values.yaml ...` it'd be:
+  #       name: example-support-center-zammad
+  #     spec:
+  #       accessModes: ["ReadWriteOnce"]
+  #       storageClassName: "-"
+  #       resources:
+  #         requests:
+  #           storage: 15Gi
+
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
#### What this PR does / why we need it:
This allows one to use the StatefulSet's capability of specifying volume claim templates. This is a must for HA so that each pod gets its own storage. Right now, increasing the replica count in the StatefulSet results in unschedulable pods because the default claim uses `accessModes: ["ReadWriteOnce"]` so only the first pod can mount it successfully.

I know that this isn't the end of the story for HA. We might also need to test and document how this would actually work. I just wanted to get this in so it at least successfully schedules multiple replicas.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
