### PR TITLE
Properly render the storageClassName

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.0.3
+version: 2.0.4
 appVersion: 3.2.0
 type: application
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -255,6 +255,6 @@ spec:
         requests:
           storage: {{ .Values.persistence.size | quote }}
       {{- with .Values.persistence.storageClass }}
-      storageClassName: "{{ .Values.persistence.storageClass }}"
+      storageClassName: "{{ . }}"
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Since `Values.persistence.storageClass` are wrapped in a `with` statement the scope changes, so setting `persistence.storageClass` causes an error when rendering the chart. Setting the value to `.` fixes that issue to match the new scope.