### PR TITLE
Support providing imagePullSecrets for private registries

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -3,5 +3,5 @@ helm-extra-args: --timeout 1200s
 check-version-increment: true
 debug: true
 chart-repos:
-  - bitnami=https://charts.bitnami.com
+  - bitnami=https://charts.bitnami.com/bitnami
   - elastic=https://helm.elastic.co

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.2.1
+version: 2.3.0
 appVersion: 3.4.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.2.0
+version: 2.2.1
 appVersion: 3.4.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -32,6 +32,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `image.repository`                                 | Container image to use                           | `zammad/zammad-docker-compose`  |
 | `image.tag`                                        | Container image tag to deploy                    | `3.4.0-4`                       |
 | `image.pullPolicy`                                 | Container pull policy                            | `IfNotPresent`                  |
+| `image.imagePullSecrets`                           | An array of imagePullSecrets                     | '[]`                            |
 | `service.type`                                     | Service type                                     | `ClusterIP`                     |
 | `service.port`                                     | Service port                                     | `8080`                          |
 | `ingress.enabled`                                  | Enable Ingress                                   | `false`                         |

--- a/zammad/requirements.yaml
+++ b/zammad/requirements.yaml
@@ -5,9 +5,9 @@ dependencies:
     condition: elasticsearch.enabled
   - name: memcached
     version: 4.2.6
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami
     condition: memcached.enabled
   - name: postgresql
     version: 8.3.4
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -17,6 +17,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.image.imagePullSecrets | nindent 6}}
+      {{- end }}
       initContainers:
       - name: zammad-init
         image: {{ .Values.image.repository }}:{{if eq .Values.image.repository "zammad/zammad-docker-compose"}}zammad-{{ end }}{{ .Values.image.tag }}

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
       securityContext:
         fsGroup: 1000
       {{- if .Values.image.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.image.imagePullSecrets | nindent 6}}
+      imagePullSecrets: {{ toYaml .Values.image.imagePullSecrets | nindent 6 }}
       {{- end }}
       initContainers:
       - name: zammad-init

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -2,6 +2,8 @@ image:
   repository: zammad/zammad-docker-compose
   tag: 3.4.0-4
   pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:

Support user provided imagePullSecrets, for when a custom image needs to be pulled from a private registry.

#### Special notes for your reviewer:

The standard convention seems to be that the `name:` component is included when someone provides a value, so I've done the same here rather than rendering it automatically.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
