### PR TITLE
Provide a mechanism to disable liveness and readiness probes

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.3.0
+version: 2.4.0
 appVersion: 3.4.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `image.repository`                                 | Container image to use                           | `zammad/zammad-docker-compose`  |
 | `image.tag`                                        | Container image tag to deploy                    | `3.4.0-4`                       |
 | `image.pullPolicy`                                 | Container pull policy                            | `IfNotPresent`                  |
-| `image.imagePullSecrets`                           | An array of imagePullSecrets                     | '[]`                            |
+| `image.imagePullSecrets`                           | An array of imagePullSecrets                     | `[]`                            |
 | `service.type`                                     | Service type                                     | `ClusterIP`                     |
 | `service.port`                                     | Service port                                     | `8080`                          |
 | `ingress.enabled`                                  | Enable Ingress                                   | `false`                         |
@@ -53,6 +53,12 @@ The following table lists the configurable parameters of the zammad chart and th
 | `envConfig.postgresql.user`                        | PostgreSql user                                  | `zammad`                        |
 | `envConfig.postgresql.db`                          | PostgreSql database                              | `zammad_production`             |
 | `envConfig.zammad.rails.trustedProxies`            | PostgreSql database                              | `"['127.0.0.1', '::1']"`        |
+| `envConfig.zammad.rails.readinessProbe`            | Readiness probe on rails                         | `true`                          |
+| `envConfig.zammad.rails.livenessProbe`             | Liveness probe on rails                          | `true`                          |
+| `envConfig.zammad.nginx.readinessProbe`            | Readiness probe on nginx                         | `true`                          |
+| `envConfig.zammad.nginx.livenessProbe`             | Liveness probe on nginx                          | `true`                          |
+| `envConfig.zammad.websocket.readinessProbe`        | Readiness probe on websocket                     | `true`                          |
+| `envConfig.zammad.websocket.livenessProbe`         | Liveness probe on websocket                      | `true`                          |
 | `autoWizard.enabled`                               | enable autowizard                                | `false`                         |
 | `autoWizard.config`                                | autowizard json config                           | `""`                            |
 | `persistence.enabled`                              | Enable persistence                               | `true`                          |

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -97,18 +97,22 @@ spec:
           mountPath: /opt/zammad
         - name: {{ template "zammad.fullname" . }}-nginx
           mountPath: /etc/nginx/sites-enabled
+        {{- if .Values.envConfig.zammad.nginx.readinessProbe }}
         readinessProbe:
           httpGet:
             path: /
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
+        {{- if .Values.envConfig.zammad.nginx.livenessProbe }}
         livenessProbe:
           httpGet:
             path: /
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
         resources:
 {{ toYaml .Values.resources.nginx | indent 10 }}
       - name: {{ .Chart.Name }}-railsserver
@@ -140,18 +144,22 @@ spec:
         volumeMounts:
          - name: {{ template "zammad.fullname" . }}
            mountPath: /opt/zammad
+        {{- if .Values.envConfig.zammad.rails.readinessProbe }}
         readinessProbe:
           httpGet:
             path: /
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
+        {{- if .Values.envConfig.zammad.rails.livenessProbe }}
         livenessProbe:
           httpGet:
             path: /
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
         resources:
 {{ toYaml .Values.resources.railsserver | indent 10 }}
       - name: {{ .Chart.Name }}-scheduler
@@ -201,16 +209,20 @@ spec:
         volumeMounts:
         - name: {{ template "zammad.fullname" . }}
           mountPath: /opt/zammad
+        {{- if .Values.envConfig.zammad.websocket.readinessProbe }}
         readinessProbe:
           tcpSocket:
             port: 6042
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
+        {{- if .Values.envConfig.zammad.websocket.livenessProbe }}
         livenessProbe:
           tcpSocket:
             port: 6042
           initialDelaySeconds: 10
           periodSeconds: 10
+        {{- end }}
         resources:
 {{ toYaml .Values.resources.websocket | indent 10 }}
     {{- with .Values.nodeSelector }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -48,6 +48,14 @@ envConfig:
   zammad:
     rails:
       trustedProxies: "['127.0.0.1', '::1']"
+      livenessProbe: true
+      readinessProbe: true
+    nginx:
+      livenessProbe: true
+      readinessProbe: true
+    websocket:
+      livenessProbe: true
+      readinessProbe: true
 
 # additional environemnt vars
 extraEnv: {}


### PR DESCRIPTION
Slow resources such as Elasticsearch and Postgres can cause false positives and cause unnecessary restarts, so it may be reasonable to disable them in some cases.

#### Which issue this PR fixes
Fixes #56

#### Special notes for your reviewer:
The fields used in values.yaml may need adjusting, but I wanted to use this as a place to start.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
