### PR TITLE
remove hard-coded replica count and define antiAffinity for it

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.4.0
+version: 2.4.1
 appVersion: 3.4.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -29,6 +29,7 @@ The following table lists the configurable parameters of the zammad chart and th
 
 | Parameter                                          | Description                                      | Default                         |
 | -------------------------------------------------- | ------------------------------------------------ | ------------------------------- |
+| `replicas`                                         | Zammad replicas                                  | `1`                             |
 | `image.repository`                                 | Container image to use                           | `zammad/zammad-docker-compose`  |
 | `image.tag`                                        | Container image tag to deploy                    | `3.4.0-18`                      |
 | `image.pullPolicy`                                 | Container pull policy                            | `IfNotPresent`                  |

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   serviceName: {{ include "zammad.name" . }}
   selector:
     matchLabels:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -153,7 +153,7 @@ tolerations: []
 
 affinity: 
     podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
+      preferredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
           matchExpressions:
           - key: app.kubernetes.io/name

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -151,7 +151,7 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: 
+affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
     - weight: 100

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -152,16 +152,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: 
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
           matchExpressions:
           - key: app.kubernetes.io/name
             operator: In
             values:
             - zammad
         topologyKey: "kubernetes.io/hostname"
-
 
 elasticsearch:
   enabled: true

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -5,6 +5,7 @@ image:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+replicas: 1
 
 service:
   type: ClusterIP
@@ -150,7 +151,16 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity: 
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - zammad
+        topologyKey: "kubernetes.io/hostname"
 
 
 elasticsearch:


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The replica count of `zammad-*` pods was hardcoded to 1. The parameter `replicas` permits to set it without the need of patching the stateful set manually. 
Then, as well, it seemed to make sense to me to define default antiAffinity for it, so the pods would not be scheduled onto the same node.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
