### PR TITLE
allow pod annotations to be specified

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zammad
-version: 2.4.0
-appVersion: 3.4.0
+version: 2.5.0
+appVersion: 3.5.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
 icon: https://raw.githubusercontent.com/zammad/zammad-documentation/master/images/zammad_logo_600x520.png

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `envConfig.zammad.websocket.livenessProbe`         | Liveness probe on websocket                      | `true`                          |
 | `autoWizard.enabled`                               | enable autowizard                                | `false`                         |
 | `autoWizard.config`                                | autowizard json config                           | `""`                            |
+| `podAnnotations`                                   | Annotations for Pods                             | `{}`                            |
 | `persistence.enabled`                              | Enable persistence                               | `true`                          |
 | `persistence.accessModes`                          | Access modes                                     | `["ReadWriteOnce"]`             |
 | `persistence.size`                                 | Volume size                                      | `15Gi`                          |

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -12,6 +12,10 @@ spec:
       {{- include "zammad.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "zammad.labels" . | nindent 8 }}
     spec:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: zammad/zammad-docker-compose
-  tag: 3.4.0-18
+  tag: 3.5.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
   # - name: "image-pull-secret"
@@ -99,6 +99,9 @@ autoWizard:
   #     ]
   #   }
 
+podAnnotations: {}
+# my-annotation: "value"
+
 persistence:
   enabled: true
   ## A manually managed Persistent Volume and Claim
@@ -156,7 +159,7 @@ affinity: {}
 elasticsearch:
   enabled: true
   image: "zammad/zammad-docker-compose"
-  imageTag: "zammad-elasticsearch-3.4.0-18"
+  imageTag: "zammad-elasticsearch-3.5.0"
   clusterName: zammad
   replicas: 1
   # Workaround to get helm test to work in GitHub action CI


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows `podAnnotations` to be set which are added to the Pod Spec of the StatefulSet.

#### Which issue this PR fixes

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md