### PR TITLE
Update railsserver container to use the correct helm variable

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.6.0
+version: 2.6.1
 appVersion: 3.5.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -138,7 +138,7 @@ spec:
           - "-e"
           - "production"
         env:
-        {{- range $key, $value := .Values.env }}
+        {{- range $key, $value := .Values.extraEnv }}
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Use the same helm variable as described in values.yaml and other containers in the pod for the railsserver. We wanted to increase the concurrency and used the extraEnv but the setting was ignored.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
