### PR TITLE
Enable scaling above 1 replica

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.6.1
+version: 2.7.0
 appVersion: 3.5.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -53,6 +53,8 @@ The following table lists the configurable parameters of the zammad chart and th
 | `envConfig.postgresql.pass`                        | PostgreSql pass                                  | `""`                            |
 | `envConfig.postgresql.user`                        | PostgreSql user                                  | `zammad`                        |
 | `envConfig.postgresql.db`                          | PostgreSql database                              | `zammad_production`             |
+| `envConfig.zammad.replicas`                        | The replica count (if >1, make sure you enable persistence) | `1`                  |
+| `envConfig.zammad.serviceAnnotations`              | Annotations to attached to the Zammad service    | `{}`                            |
 | `envConfig.zammad.rails.trustedProxies`            | PostgreSql database                              | `"['127.0.0.1', '::1']"`        |
 | `envConfig.zammad.rails.readinessProbe`            | Readiness probe on rails                         | `true`                          |
 | `envConfig.zammad.rails.livenessProbe`             | Liveness probe on rails                          | `true`                          |
@@ -90,13 +92,19 @@ The following table lists the configurable parameters of the zammad chart and th
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-### Important note for  NFS filesystems
+### Important note for NFS filesystems
 
 For persistent volumes, NFS filesystems should work correctly for **Elasticsearch** and **PostgreSQL**; however, errors will occur if Zammad itself uses an NFS-based persistent volume.  Websockets will break completely.  This is particularly bad news for receiving notifications from the application and using the Chat module.
 
 Don't use an NFS-based storage class for Zammad's persistent volume.
 
 This is relevant to **EFS** for AWS users, as well.
+
+### Important note for replica scaling
+
+If you set `envConfig.zammad.replicas` to a value greater than 1 then you need some sort of session persistence (sometimes called sticky sessions).
+
+Enabling session persistence is outside the scope of this documentation, but is typically enabled on your Ingress controller or load balancer. Because there are so many acceptable ways to implement sticky sessions there won't be a warning or error if you forget to do this.
 
 ## Using zammad
 

--- a/zammad/templates/service.yaml
+++ b/zammad/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "zammad.fullname" . }}
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
+  {{- with .Values.envConfig.zammad.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.envConfig.zammad.replicas }}
   serviceName: {{ include "zammad.name" . }}
   selector:
     matchLabels:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -48,6 +48,8 @@ envConfig:
     # needs to be the same as the postgresql.postgresqlDatabase
     db: zammad_production
   zammad:
+    replicas: 1
+    serviceAnnotations: {}
     rails:
       trustedProxies: "['127.0.0.1', '::1']"
       livenessProbe: true


### PR DESCRIPTION
In some cases there may be a desire to scale Zammad to more than one replica.

If more than one replica is configured sticky sessions should also be enabled. It's hard to test for this since different ingress controllers and load balancers handle sticky sessions in different ways, so I've documented that there are no warnings (hopefully folks read this portion)

Some ingress controllers require an annotation on the service itself (e.g. Traefik 2+), so I've added support for setting that too.

#### Checklist
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
