### PR TITLE
fix #63, add default credentials for elasticsearch, rework check condition

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zammad
-version: 2.6.1
+version: 2.6.2
 appVersion: 3.5.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -43,8 +43,8 @@ The following table lists the configurable parameters of the zammad chart and th
 | `envConfig.elasticsearch.schema`                   | Elasticsearch schema                             | `http`                          |
 | `envConfig.elasticsearch.host`                     | Elasticsearch host                               | `zammad-master`                 |
 | `envConfig.elasticsearch.port`                     | Elasticsearch port                               | `9200`                          |
-| `envConfig.elasticsearch.user`                     | Elasticsearch user                               | `""`                            |
-| `envConfig.elasticsearch.pass`                     | Elasticsearch pass                               | `""`                            |
+| `envConfig.elasticsearch.user`                     | Elasticsearch user                               | `"zammad"`                            |
+| `envConfig.elasticsearch.pass`                     | Elasticsearch pass                               | `"zammad"`                            |
 | `envConfig.elasticsearch.reindex`                  | Elasticsearch reindex is run on start            | `true`                          |
 | `envConfig.memcached.host`                         | Memcached host                                   | `zammad-memcached`              |
 | `envConfig.memcached.port`                         | Memcached port                                   | `11211`                         |

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -9,7 +9,7 @@ data:
     #!/bin/bash
     set -e
     bundle exec rails r 'Setting.set("es_url", "{{ .Values.envConfig.elasticsearch.schema }}://{{ if .Values.elasticsearch.enabled }}zammad-master{{ else }}{{ .Values.envConfig.elasticsearch.host }}{{ end }}:{{ .Values.envConfig.elasticsearch.port }}")'
-    {{- if and .Values.elasticsearch.user .Values.elasticsearch.pass }}
+    {{- if and .Values.envConfig.elasticsearch.user .Values.envConfig.elasticsearch.pass }}
     bundle exec rails r 'Setting.set("es_user", "{{ .Values.envConfig.elasticsearch.user }}")'
     bundle exec rails r 'Setting.set("es_password", "{{ .Values.envConfig.elasticsearch.pass }}")'
     {{ end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -30,8 +30,8 @@ envConfig:
     schema: http
     host: zammad-master
     port: 9200
-    user: ""
-    pass: ""
+    user: "zammad"
+    pass: "zammad"
     reindex: true
   memcached:
     # host env var is only used when memcached.enabled is false


### PR DESCRIPTION
#### What this PR does / why we need it:

The check now defaults to the env section of the variables. Default credentials are provided as Helm evaluates an empty string to false.


#### Which issue this PR fixes
#63 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
