### PR TITLE
add posibility to run zammad without elasticsearch

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 3.1.0
+version: 3.2.0
 appVersion: 3.6.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -78,7 +78,8 @@ The following table lists the configurable parameters of the zammad chart and th
 | `nodeSelector`                                     | Node Selector                                    | `{}`                            |
 | `tolerations`                                      | Tolerations                                      | `[]`                            |
 | `affinity`                                         | Affinity                                         | `{}`                            |
-| `elasticsearch.enabled`                            | Use Elasticsearch dependency                     | `true`                          |
+| `elasticsearch.enabled`                            | Use Elasticsearch chart dependency               | `true`                          |
+| `elasticsearch.enableInitialisation`               | Run zammad specific Elasticsearch initialisation | `true`                          |
 | `elasticsearch.image`                              | Elasticsearch docker image                       | `zammad/zammad-docker-compose`  |
 | `elasticsearch.imageTag`                           | Elasticsearch docker image tag                   | `zammad-elasticsearch-3.6.0-1`  |
 | `elasticsearch.clusterName`                        | Elasticsearch cluster name                       | `zammad`                        |

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
 data:
+{{ if .Values.elasticsearch.enableInitialisation }}
   elasticsearch-init: |-
     #!/bin/bash
     set -e
@@ -17,6 +18,7 @@ data:
     bundle exec rake searchindex:rebuild
     {{ end }}
     echo "elasticsearch init complete :)"
+{{ end }}
   postgresql-init: |-
     #!/bin/bash
     set -e

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -62,6 +62,7 @@ spec:
           mountPath: /docker-entrypoint.sh
           readOnly: true
           subPath: postgresql-init
+      {{ if .Values.elasticsearch.enableInitialisation }}
       - name: elasticsearch-init
         image: {{ .Values.image.repository }}:{{if eq .Values.image.repository "zammad/zammad-docker-compose"}}zammad-{{ end }}{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -80,6 +81,7 @@ spec:
           mountPath: /docker-entrypoint.sh
           readOnly: true
           subPath: elasticsearch-init
+      {{ end }}
       containers:
       - name: {{ .Chart.Name }}-nginx
         image: {{ .Values.image.repository }}:{{if eq .Values.image.repository "zammad/zammad-docker-compose"}}zammad-{{ end }}{{ .Values.image.tag }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -165,7 +165,10 @@ affinity: {}
 
 
 elasticsearch:
+  # enable / disable elasticsearch chart dependency
   enabled: true
+  # enable / disable zammad specific elasticsearch initialisation - disable this to run zammad without elasticsearch
+  enableInitialisation: true
   image: "zammad/zammad-docker-compose"
   imageTag: "zammad-elasticsearch-3.6.0-1"
   clusterName: zammad


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

There is a very limited use-case to run zammad without elasticsearch, this change will introduce a new variable to disable the zammad elasticsearch initialisation


#### Which issue this PR fixes
  - fixes #74 


#### Special notes for your reviewer:


#### Checklist

- [X] Chart Version bumped
- [X] Variables are documented in the README.md


#### Demo

```yaml
elasticsearch:
  enabled: false
  enableInitialisation: false
```
