### PR TITLE
StatefulSet: Remove duplicate `securityContext`

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.1.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -19,8 +19,6 @@ spec:
       labels:
         {{- include "zammad.labels" . | nindent 8 }}
     spec:
-      securityContext:
-        fsGroup: 1000
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.image.imagePullSecrets | nindent 6 }}
       {{- end }}
@@ -105,8 +103,8 @@ spec:
         image: {{ .Values.image.repository }}:{{if eq .Values.image.repository "zammad/zammad-docker-compose"}}zammad-{{ end }}{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - /usr/sbin/nginx 
-          - -g 
+          - /usr/sbin/nginx
+          - -g
           - 'daemon off;'
         env:
           {{- range $key, $value := .Values.extraEnv }}
@@ -148,7 +146,7 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        command: 
+        command:
           - "bundle"
           - "exec"
           - "rails"
@@ -195,7 +193,7 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        command: 
+        command:
           - "bundle"
           - "exec"
           - "script/scheduler.rb"
@@ -216,7 +214,7 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-        command: 
+        command:
           - "bundle"
           - "exec"
           - "script/websocket-server.rb"
@@ -288,7 +286,7 @@ spec:
   - metadata:
       name: {{ template "zammad.fullname" . }}
     spec:
-      accessModes: 
+      accessModes:
       {{- range .Values.persistence.accessModes }}
         - {{ . | quote }}
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Jack O'Sullivan <jackos1998@gmail.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The `StatefulSet` template contains a duplicate `securityContext` key, which results in invalid YAML.

#### Checklist

- [x] Chart Version bumped
