### PR TITLE
Add volumePermissions initContainer

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 4.0.3
+version: 4.1.0
 appVersion: 4.1.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -66,6 +66,10 @@ The following table lists the configurable parameters of the zammad chart and th
 | `autoWizard.enabled`                               | enable autowizard                                | `false`                         |
 | `autoWizard.config`                                | autowizard json config                           | `""`                            |
 | `podAnnotations`                                   | Annotations for Pods                             | `{}`                            |
+| `volumePermissions.enabled`                        | Enable data volume permissions correction        | `false`                         |
+| `volumePermissions.image.repository`               | initContainer image to use                       | `alpine`                        |
+| `volumePermissions.image.tag`                      | initContainer image tag to deploy                | `3.14`                          |
+| `volumePermissions.image.pullPolicy`               | initContainer pull policy                        | `IfNotPresent`                  |
 | `persistence.enabled`                              | Enable persistence                               | `true`                          |
 | `persistence.accessModes`                          | Access modes                                     | `["ReadWriteOnce"]`             |
 | `persistence.size`                                 | Volume size                                      | `15Gi`                          |

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -23,6 +23,22 @@ spec:
       imagePullSecrets: {{ toYaml .Values.image.imagePullSecrets | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.volumePermissions.enabled }}
+      - name: data-chmod
+        image: "{{ .Values.volumePermissions.image.repository }}:{{ .Values.volumePermissions.image.tag }}"
+        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -cx
+        - |
+          chown 1000:1000 -R /opt/zammad
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - name: {{ template "zammad.fullname" . }}
+          mountPath: /opt/zammad
+      {{- end }}
       - name: zammad-init
         image: {{ .Values.image.repository }}:{{if eq .Values.image.repository "zammad/zammad-docker-compose"}}zammad-{{ end }}{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -127,6 +127,12 @@ autoWizard:
 podAnnotations: {}
   # my-annotation: "value"
 
+volumePermissions:
+  enabled: false
+  image:
+    repository: alpine
+    tag: '3.14'
+    pullPolicy: IfNotPresent
 persistence:
   enabled: true
   ## A manually managed Persistent Volume and Claim


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When running containers as a non-root user, volumes are often mounted as not belonging to that user. This can be fixed by running a `chown` in an `initContainer` that runs as root. This PR adds a `volumePermissions` section to `values.yaml` which can optionally enable a simple `alpine` container to run on init of the main pod and fix permissions in the data volume.

#### Which issue this PR fixes

  - fixes #93 


#### Checklist

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
