### PR TITLE
Maintenance: Raise helm to Zammad 5.0.3 and ES 7.16.1

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zammad
-version: 6.0.1
-appVersion: 5.0.2
+version: 6.0.2
+appVersion: 5.0.3
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
 icon: https://raw.githubusercontent.com/zammad/zammad-documentation/master/images/zammad_logo_600x520.png
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: elasticsearch
     repository: https://helm.elastic.co
-    version: 7.15.0
+    version: 7.16.1
     condition: zammadConfig.elasticsearch.enabled
   - name: memcached
     version: 5.15.5

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | Parameter                                      | Description                                      | Default                         |
 | ---------------------------------------------- | ------------------------------------------------ | ------------------------------- |
 | `image.repository`                             | Container image to use                           | `zammad/zammad-docker-compose`  |
-| `image.tag`                                    | Container image tag to deploy                    | `5.0.2-1`                       |
+| `image.tag`                                    | Container image tag to deploy                    | `5.0.3-7`                       |
 | `image.pullPolicy`                             | Container pull policy                            | `IfNotPresent`                  |
 | `image.imagePullSecrets`                       | An array of imagePullSecrets                     | `[]`                            |
 | `service.type`                                 | Service type                                     | `ClusterIP`                     |

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: zammad/zammad-docker-compose
-  tag: 5.0.2-1
+  tag: 5.0.3-7
   pullPolicy: IfNotPresent
   imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -274,7 +274,7 @@ podSecurityPolicy:
 # Settings for the elasticsearch subchart
 elasticsearch:
   image: "zammad/zammad-docker-compose"
-  imageTag: "zammad-elasticsearch-5.0.2-1"
+  imageTag: "zammad-elasticsearch-5.0.3-7"
   clusterName: zammad
   replicas: 1
   # Workaround to get helm test to work in GitHub action CI


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR bumps the used Elasticsearch version to 7.16.1.
Also raises Zammad version to 5.0.3.

Please note that these lines confused me *a lot*:
* https://github.com/zammad/zammad-helm/commit/398893e729b2b9fef795d17919617828a98462ab#diff-c3222dbe88229350c6c258a9f98e407352ce8af5feae65eb84b54e8a5b4eb800R20
* https://github.com/zammad/zammad-helm/commit/398893e729b2b9fef795d17919617828a98462ab#diff-f8ab6f5a50d29a4ca02a1e8d2aa61bc30a97b0b6bc72687c78bb9959549e11f6R277
they feel duplicate to me.


#### Which issue this PR fixes
Fixed log4j of ES.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
