### PR TITLE
Maintenance: Raise version to 5.0.3-14 & include ES 7.16.2

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 6.0.2
+version: 6.0.3
 appVersion: 5.0.3
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: elasticsearch
     repository: https://helm.elastic.co
-    version: 7.16.1
+    version: 7.16.2
     condition: zammadConfig.elasticsearch.enabled
   - name: memcached
     version: 5.15.5

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `podSecurityPolicy.annotations`                | PodSecurityPolicy annotations                    | `{}`                            |
 | `podSecurityPolicy.name`                       | PodSecurityPolicy name                           | `""`                            |
 | `elasticsearch.image`                          | Elasticsearch docker image                       | `zammad/zammad-docker-compose`  |
-| `elasticsearch.imageTag`                       | Elasticsearch docker image tag                   | `zammad-elasticsearch-5.0.2-1`  |
+| `elasticsearch.imageTag`                       | Elasticsearch docker image tag                   | `zammad-elasticsearch-5.0.3-14` |
 | `elasticsearch.clusterName`                    | Elasticsearch cluster name                       | `zammad`                        |
 | `elasticsearch.replicas`                       | Elasticsearch replicas                           | `1`                             |
 | `elasticsearch.clusterHealthCheckParams`       | Workaround to get ES test work in GitHubCI       | `"timeout=1s"`                  |

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | Parameter                                      | Description                                      | Default                         |
 | ---------------------------------------------- | ------------------------------------------------ | ------------------------------- |
 | `image.repository`                             | Container image to use                           | `zammad/zammad-docker-compose`  |
-| `image.tag`                                    | Container image tag to deploy                    | `5.0.3-7`                       |
+| `image.tag`                                    | Container image tag to deploy                    | `5.0.3-14`                       |
 | `image.pullPolicy`                             | Container pull policy                            | `IfNotPresent`                  |
 | `image.imagePullSecrets`                       | An array of imagePullSecrets                     | `[]`                            |
 | `service.type`                                 | Service type                                     | `ClusterIP`                     |

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -274,7 +274,7 @@ podSecurityPolicy:
 # Settings for the elasticsearch subchart
 elasticsearch:
   image: "zammad/zammad-docker-compose"
-  imageTag: "zammad-elasticsearch-5.0.3-7"
+  imageTag: "zammad-elasticsearch-5.0.3-14"
   clusterName: zammad
   replicas: 1
   # Workaround to get helm test to work in GitHub action CI

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: zammad/zammad-docker-compose
-  tag: 5.0.3-7
+  tag: 5.0.3-14
   pullPolicy: IfNotPresent
   imagePullSecrets: []
     # - name: "image-pull-secret"


### PR DESCRIPTION
#### What this PR does / why we need it:


#### Which issue this PR fixes

This PR provides latest avaiable Zammad 5.0.3 version with Elasticsearch 7.16.2.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
