### PR TITLE
feat: add optional nginx config for knowledge base url

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 6.0.5
+version: 6.1.0
 appVersion: 5.0.3
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 6.0.4
+version: 6.0.5
 appVersion: 5.0.3
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `zammadConfig.memcached.port`                  | Memcached port                                   | `11211`                         |
 | `zammadConfig.nginx.websocketExtraHeaders`     | Additional nginx headers for ws location         | `[]`                            |
 | `zammadConfig.nginx.extraHeaders`              | Additional nginx headers for / location          | `[]`                            |
+| `zammadConfig.nginx.knowledgeBaseUrl`          | Value of custom url for knowledge base           | `""`                            |
 | `zammadConfig.nginx.resources`                 | Resource usage of Zammad's nginx container       | `{}`                            |
 | `zammadConfig.nginx.livenessProbe`             | Liveness probe for the nginx container           | see values.yaml                 |
 | `zammadConfig.nginx.readinessProbe`            | Readiness probe for the nginx container          | see values.yaml                 |

--- a/zammad/templates/configmap-nginx.yaml
+++ b/zammad/templates/configmap-nginx.yaml
@@ -32,6 +32,13 @@ data:
 
         client_max_body_size 50M;
 
+        {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
+        if ($host = {{ .Values.zammadConfig.nginx.knowledgeBaseUrl }} ) {
+            rewrite ^/(api|assets)/(.*)$ /$1/$2 last;
+            rewrite ^(.*)$ /help$1 last;
+        }
+        {{- end }}
+
         location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico) {
             expires max;
         }
@@ -50,6 +57,9 @@ data:
         }
 
         location / {
+            {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
+            proxy_set_header X-ORIGINAL-URL $request_uri;
+            {{- end }}
             proxy_set_header Host $http_host;
             proxy_set_header CLIENT_IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/zammad/templates/configmap-nginx.yaml
+++ b/zammad/templates/configmap-nginx.yaml
@@ -33,10 +33,15 @@ data:
         client_max_body_size 50M;
 
         {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
-        if ($host = {{ .Values.zammadConfig.nginx.knowledgeBaseUrl }} ) {
+        {{ if hasPrefix "/" .Values.zammadConfig.nginx.knowledgeBaseUrl }}
+        rewrite ^{{ .Values.zammadConfig.nginx.knowledgeBaseUrl }}(.*)$ /help$1 last;
+        {{- else }}
+        {{- $url := urlParse ( list "//" .Values.zammadConfig.nginx.knowledgeBaseUrl | join "" ) }}
+        if ($host = {{ $url.host }} ) {
             rewrite ^/(api|assets)/(.*)$ /$1/$2 last;
-            rewrite ^(.*)$ /help$1 last;
+            rewrite ^{{ $url.path }}(.*)$ /help$1 last;
         }
+        {{- end }}
         {{- end }}
 
         location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico) {

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -66,6 +66,7 @@ zammadConfig:
       # - 'HeaderName "Header Value"'
     websocketExtraHeaders: []
       # - 'HeaderName "Header Value"'
+    knowledgeBaseUrl: ""
     livenessProbe:
       httpGet:
         path: /


### PR DESCRIPTION
Signed-off-by: Raphael Jasjukaitis <hello@raphael-jasjukaitis.de>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Zammad has the feature to add a custom url for the knowledge base. If enabled, `knowledgeBaseUrl` can be set so nginx will be configured accordingly.

#### Which issue this PR fixes
-

#### Special notes for your reviewer:
-

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
