### PR TITLE
Raise helm-chart to Zammad 5.1

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 6.0.5
+version: 6.1.0
 appVersion: 5.1.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: zammad
-version: 6.0.4
-appVersion: 5.0.3
+version: 6.0.5
+appVersion: 5.1.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
-icon: https://raw.githubusercontent.com/zammad/zammad-documentation/master/images/zammad_logo_600x520.png
+icon: https://raw.githubusercontent.com/zammad/zammad-documentation/main/images/zammad_logo_600x520.png
 sources:
   - https://github.com/zammad/zammad
   - https://github.com/zammad/zammad-docker-compose

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | Parameter                                      | Description                                      | Default                         |
 | ---------------------------------------------- | ------------------------------------------------ | ------------------------------- |
 | `image.repository`                             | Container image to use                           | `zammad/zammad-docker-compose`  |
-| `image.tag`                                    | Container image tag to deploy                    | `5.0.3-31`                       |
+| `image.tag`                                    | Container image tag to deploy                    | `5.1.0-4`                       |
 | `image.pullPolicy`                             | Container pull policy                            | `IfNotPresent`                  |
 | `image.imagePullSecrets`                       | An array of imagePullSecrets                     | `[]`                            |
 | `service.type`                                 | Service type                                     | `ClusterIP`                     |
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `podSecurityPolicy.annotations`                | PodSecurityPolicy annotations                    | `{}`                            |
 | `podSecurityPolicy.name`                       | PodSecurityPolicy name                           | `""`                            |
 | `elasticsearch.image`                          | Elasticsearch docker image                       | `zammad/zammad-docker-compose`  |
-| `elasticsearch.imageTag`                       | Elasticsearch docker image tag                   | `zammad-elasticsearch-5.0.3-31` |
+| `elasticsearch.imageTag`                       | Elasticsearch docker image tag                   | `zammad-elasticsearch-5.1.0-4` |
 | `elasticsearch.clusterName`                    | Elasticsearch cluster name                       | `zammad`                        |
 | `elasticsearch.replicas`                       | Elasticsearch replicas                           | `1`                             |
 | `elasticsearch.clusterHealthCheckParams`       | Workaround to get ES test work in GitHubCI       | `"timeout=1s"`                  |
@@ -133,7 +133,7 @@ Open your browser on <http://localhost:8080>
 
 ## Upgrading
 
-### From chart version 6.0.3 to 6.0.x
+### From chart version 6.0.4 to 6.0.x
 
 - minimum helm version now is 3.2.0+
 - minimum Kubernetes version now is 1.19+

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: zammad/zammad-docker-compose
-  tag: 5.0.3-31
+  tag: 5.1.0-4
   pullPolicy: IfNotPresent
   imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -274,7 +274,7 @@ podSecurityPolicy:
 # Settings for the elasticsearch subchart
 elasticsearch:
   image: "zammad/zammad-docker-compose"
-  imageTag: "zammad-elasticsearch-5.0.3-31"
+  imageTag: "zammad-elasticsearch-5.1.0-4"
   clusterName: zammad
   replicas: 1
   # Workaround to get helm test to work in GitHub action CI


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR raises the helm-charts Zammad version to 5.1.0-4 which is the latest available docker version.

#### Which issue this PR fixes
--


#### Special notes for your reviewer:


#### Checklist
- [x] Chart Version bumped
