### PR TITLE
Add option to configure NGINX's trusted proxies

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 6.7.1
+version: 6.8.0
 appVersion: 5.2.1
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the zammad chart and th
 | `zammadConfig.memcached.enabled`            | Use Memcached dependency                         | `true`                          |
 | `zammadConfig.memcached.host`               | Memcached host                                   | `zammad-memcached`              |
 | `zammadConfig.memcached.port`               | Memcached port                                   | `11211`                         |
+| `zammadConfig.nginx.trustedProxies`         | Configure `set_real_ip_from` to trust proxies    | `[]`                            |
 | `zammadConfig.nginx.websocketExtraHeaders`  | Additional nginx headers for ws location         | `[]`                            |
 | `zammadConfig.nginx.extraHeaders`           | Additional nginx headers for / location          | `[]`                            |
 | `zammadConfig.nginx.knowledgeBaseUrl`       | Value of custom URL for knowledge base           | `""`                            |

--- a/zammad/templates/configmap-nginx.yaml
+++ b/zammad/templates/configmap-nginx.yaml
@@ -32,6 +32,11 @@ data:
 
         client_max_body_size 50M;
 
+        {{- /* Trusted proxies */}}
+        {{ range .Values.zammadConfig.nginx.trustedProxies }}
+        set_real_ip_from {{ . }};
+        {{- end }}
+
         {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
         {{ if hasPrefix "/" .Values.zammadConfig.nginx.knowledgeBaseUrl }}
         rewrite ^{{ .Values.zammadConfig.nginx.knowledgeBaseUrl }}(.*)$ /help$1 last;

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -62,6 +62,7 @@ zammadConfig:
     host: zammad-memcached
     port: 11211
   nginx:
+    trustedProxies: []
     extraHeaders: []
       # - 'HeaderName "Header Value"'
     websocketExtraHeaders: []


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds the `zammadConfig.nginx.trustedProxies` configuration option which allows trusted proxies to be defined.

#### Which issue this PR fixes

- fixes #150

#### Special notes for your reviewer:

Doesn't trust any proxy by default.

#### Checklist

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
