### PR TITLE
Add missing /cable endpoint

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 9.0.2
+version: 9.0.3
 appVersion: 6.0.0-32
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/configmap-nginx.yaml
+++ b/zammad/templates/configmap-nginx.yaml
@@ -76,6 +76,15 @@ data:
             proxy_pass http://zammad-websocket;
         }
 
+        location /cable {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header CLIENT_IP $remote_addr;
+            proxy_read_timeout 86400;
+            proxy_pass http://zammad-railsserver;
+        }
+
         location / {
             {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
             proxy_set_header X-ORIGINAL-URL $request_uri;


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Fixes Zammad failing to connect to the new /cable WebSocket endpoint in Zammad 6

#### Checklist

- [x] Chart Version bumped
