### PR TITLE
Ensure the volume names are consistent across configurations

### DIFF
--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -414,11 +414,11 @@ spec:
         - name: {{ include "zammad.fullname" . }}-tmp
           {{- toYaml .Values.zammadConfig.tmpDirVolume | nindent 10 }}
   {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
-        - name: {{ template "zammad.fullname" . }}
+        - name: {{ template "zammad.fullname" . }}-var
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "zammad.fullname" .) }}
   {{- else if not .Values.persistence.enabled }}
-      - name: {{ template "zammad.fullname" . }}
+      - name: {{ template "zammad.fullname" . }}-var
         emptyDir:
           sizeLimit: {{ .Values.persistence.size | quote }}
   {{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

-  It ensures that no matter what kind of volume/persistence setting you run it has the same name. Otherwise the stateful set is invalid

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #201

#### Special notes for your reviewer

- .

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Upgrading instructions are documented in the README.md
