### PR TITLE
moving rails TMP into existing writable pvc and adding an init job to …

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 9.0.5
+version: 9.0.6
 appVersion: 6.0.0-66
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -60,6 +60,9 @@ zammadConfig:
       securityContext:
         runAsUser: null
 
+railsserverTmp:
+  enabled: true
+
 elasticsearch:
   sysctlImage:
     enabled: false

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -59,9 +59,21 @@ zammadConfig:
       extraRsyncParams: "--no-perms --omit-dir-times"
       securityContext:
         runAsUser: null
+  railsserver:
+    tmpdir: "/opt/zammad/var/tmp"
 
-railsserverTmp:
-  enabled: true
+
+initContainers:
+  - name: railsserver-tmp-init
+    image: "alpine:3.18.2"
+    command:
+      - /bin/sh
+      - -cx
+      - |
+        mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
+    volumeMounts:
+      - name: zammad-var
+        mountPath: /opt/zammad/var
 
 elasticsearch:
   sysctlImage:

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -63,26 +63,6 @@ spec:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
         {{- end }}
-        {{- if .Values.railsserverTmp.enabled }}
-        - name: railsserver-tmp-init
-          image: "{{ .Values.railsserverTmp.image.repository }}:{{ .Values.railsserverTmp.image.tag }}"
-          command:
-            - /bin/sh
-            - -cx
-            - |
-              mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
-          {{- with .Values.zammadConfig.initContainers.railsserverTmp.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.zammadConfig.railsserverTmp }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: {{ template "zammad.fullname" . }}-var
-              mountPath: /opt/zammad/var
-        {{- end }}
         - name: zammad-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -278,7 +258,7 @@ spec:
             - "production"
           env:
             - name: TMP
-              value: "/opt/zammad/var/tmp"
+              value: {{ .Values.zammadConfig.railsserver.tmpdir }}
           {{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -63,6 +63,26 @@ spec:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
         {{- end }}
+        {{- if .Values.railsserverTmp.enabled }}
+        - name: railsserver-tmp-init
+          image: "{{ .Values.railsserverTmp.image.repository }}:{{ .Values.railsserverTmp.image.tag }}"
+          command:
+            - /bin/sh
+            - -cx
+            - |
+              mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
+          {{- with .Values.zammadConfig.initContainers.railsserverTmp.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.zammadConfig.railsserverTmp }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/var
+        {{- end }}
         - name: zammad-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -258,7 +278,7 @@ spec:
             - "production"
           env:
             - name: TMP
-              value: "/opt/zammad/tmp"
+              value: "/opt/zammad/var/tmp"
           {{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -265,6 +265,21 @@ zammadConfig:
             - ALL
         runAsNonRoot: false
         runAsUser: 0
+    railsserverTmp:
+      resources: {}
+        # requests:
+        #   cpu: 100m
+        #   memory: 256Mi
+        # limits:
+        #   cpu: 200m
+        #   memory: 512Mi
+      securityContext:
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: false
+        runAsUser: 0
     zammad:
       # set extra params to rsync command
       extraRsyncParams: ""
@@ -329,6 +344,13 @@ podAnnotations: {}
   # my-annotation: "value"
 
 volumePermissions:
+  enabled: false
+  image:
+    repository: alpine
+    tag: "3.18.2"
+    pullPolicy: IfNotPresent
+
+railsserverTmp:
   enabled: false
   image:
     repository: alpine

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -158,6 +158,7 @@ zammadConfig:
       privileged: false
     trustedProxies: "['127.0.0.1', '::1']"
     webConcurrency: 0
+    tmpdir: "/opt/zammad/tmp"
 
   redis:
     # enable/disable redis chart dependency
@@ -265,21 +266,6 @@ zammadConfig:
             - ALL
         runAsNonRoot: false
         runAsUser: 0
-    railsserverTmp:
-      resources: {}
-        # requests:
-        #   cpu: 100m
-        #   memory: 256Mi
-        # limits:
-        #   cpu: 200m
-        #   memory: 512Mi
-      securityContext:
-        readOnlyRootFilesystem: true
-        capabilities:
-          drop:
-            - ALL
-        runAsNonRoot: false
-        runAsUser: 0
     zammad:
       # set extra params to rsync command
       extraRsyncParams: ""
@@ -344,13 +330,6 @@ podAnnotations: {}
   # my-annotation: "value"
 
 volumePermissions:
-  enabled: false
-  image:
-    repository: alpine
-    tag: "3.18.2"
-    pullPolicy: IfNotPresent
-
-railsserverTmp:
   enabled: false
   image:
     repository: alpine


### PR DESCRIPTION
…set permissions not world-writable #205

#### What this PR does / why we need it

cant upload files, using Openshift 

#### Which issue this PR fixes

- fixes #205

#### Special notes for your reviewer

It was not possible to use an simple empty dir, rails wants [a not world-writable](https://stackoverflow.com/questions/21117878/ruby-could-not-find-a-temporary-directory/31182540#31182540) directory.

So I added a new directory (`/opt/zammad/var/tmp`) 

* in the existing writable PVC to get Openshift satisfied to not write into the container, but in a PVC
* changed permissions to get rails satisfied to have a "not world-writable" directory.

Sadly I had to use an additional optional [init container](https://stackoverflow.com/questions/66857727/mounting-kubernetes-volume-with-user-permission), but tried to use the pattern from `data-chmod`.


The initcontainer `railsserver-tmp-init` is optional and default false, the only thing I changed in the existing statefulset is TMP directory to `/opt/zammad/var/tmp`.

I could use an helm var here, but I am not sure.

#### Checklist

- [x] Chart Version bumped
- [x] Upgrading instructions are documented in the README.md
