### PR TITLE
Removemextrarsyncparams

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 9.0.7
+version: 9.0.8
 appVersion: 6.0.0-66
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -44,7 +44,6 @@ This is relevant to **EFS** for AWS users, as well.
 
 To run OpenShift unprivileged and with [arbitrary UIDs and GIDs](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids):
 
-- Add the extraRsyncParams `--no-perms --omit-dir-times`.
 - [Delete the default key](https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key)  `securityContext` and `zammadConfig.initContainers.zammad.securityContext.runAsUser` with `null`.
 - Disable if used:
   - also `podSecurityContext` in all subcharts.
@@ -56,7 +55,6 @@ securityContext: null
 zammadConfig:
   initContainers:
     zammad:
-      extraRsyncParams: "--no-perms --omit-dir-times"
       securityContext:
         runAsUser: null
   railsserver:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -267,8 +267,6 @@ zammadConfig:
         runAsNonRoot: false
         runAsUser: 0
     zammad:
-      # set extra params to rsync command
-      extraRsyncParams: ""
       resources: {}
         # requests:
         #   cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it

Variable extraRsyncParams  is obsolete. [extraRsyncParams does not appear in code](https://github.com/search?q=repo%3Azammad%2Fzammad-helm%20extraRsyncParams&type=code)

#### Checklist

- [x] Chart Version bumped
- [x] Upgrading instructions are documented in the README.md
