### PR TITLE
Added missed mount for init container

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 9.0.7
+version: 9.0.8
 appVersion: 6.0.0-66
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -62,6 +62,8 @@ spec:
           volumeMounts:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
         {{- end }}
         - name: zammad-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -99,6 +101,8 @@ spec:
           volumeMounts:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
             - name: {{ template "zammad.fullname" . }}-init
               mountPath: /docker-entrypoint.sh
               readOnly: true
@@ -139,6 +143,8 @@ spec:
           volumeMounts:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
             - name: {{ template "zammad.fullname" . }}-init
               mountPath: /docker-entrypoint.sh
               readOnly: true
@@ -187,6 +193,8 @@ spec:
           volumeMounts:
           - name: {{ template "zammad.fullname" . }}-var
             mountPath: /opt/zammad/var
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
           - name: {{ template "zammad.fullname" . }}-init
             mountPath: /docker-entrypoint.sh
             readOnly: true

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -193,8 +193,8 @@ spec:
           volumeMounts:
           - name: {{ template "zammad.fullname" . }}-var
             mountPath: /opt/zammad/var
-            - name: {{ template "zammad.fullname" . }}-var
-              mountPath: /opt/zammad/storage
+          - name: {{ template "zammad.fullname" . }}-var
+            mountPath: /opt/zammad/storage
           - name: {{ template "zammad.fullname" . }}-init
             mountPath: /docker-entrypoint.sh
             readOnly: true


### PR DESCRIPTION
The problem is init containers don't have possibility for checking logo and any files

#### What this PR does / why we need it

- Missed mounting for init container

#### Which issue this PR fixes
- issue: https://github.com/zammad/zammad-helm/issues/212
- issue: https://github.com/zammad/zammad-helm/issues/200


