### PR TITLE
document using existing secrets for the subcharts 

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.0.2
+version: 10.0.3
 appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -426,6 +426,11 @@ elasticsearch:
     heapSize: 512m
     masterOnly: false
     replicaCount: 1
+  # To use an existing Kubernetes secret containing the credentials,
+  # remove the comments on the lines below and adjust them accordingly
+  #
+  # security:
+  #   existingSecret: elastic-credentials
 
 # settings for the memcached subchart
 memcached:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -441,12 +441,25 @@ memcached:
 # settings for the postgres subchart
 postgresql:
   auth:
-    postgresPassword: "zammad"
     username: "zammad"
-    password: "zammad"
-    database: "zammad_production"
     replicationUsername: repl_user
+    database: "zammad_production"
+
+    # Passwords
+    postgresPassword: "zammad"
+    password: "zammad"
     replicationPassword: "zammad"
+
+    # To avoid passwords in your values.yaml, you can comment out the 3 lines above
+    # and use an existing Kubernetes secret. Remove the comments on the lines below
+    # and adjust them accordingly
+    #
+    # existingSecret: postgresql-pass
+    # secretKeys:
+    #   adminPasswordKey: postgresql-admin-password
+    #   userPasswordKey: postgresql-pass
+    #   replicationPasswordKey: postgresql-replication-password
+    #
   resources: {}
     # requests:
     #   cpu: 250m

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -473,6 +473,12 @@ redis:
   architecture: standalone
   auth:
     password: zammad
+    # To avoid passwords in your values.yaml, you can comment out the line above
+    # and use an existing Kubernetes secret. Remove the comments on the lines below
+    # and adjust them accordingly
+    #
+    # existingSecret: redis-pass
+    # existingSecretPasswordKey: redis-password
   master:
     resources: {}
     # limits:


### PR DESCRIPTION
#### What this PR does / why we need it

Using the `secrets:` section the user can use existing secrets with the zammad chart. But the credentials for the subcharts are still in plaintext in the `values.yaml` file.

This PR adds commented examples on how to configure the subcharts to use the existing secrets.

#### Which issue this PR fixes

None. It could have been part of #76 that fixes #73

#### Special notes for your reviewer

1. Authentication for the memcached subchart is currently not being used at all, it seems. So I did not document anything there.

2. I am a little fishy on the details regarding the elasticsearch subchart. Enabling the `secrets.elasticsearch.useExisting` value leads to the secret being mounted in the zammad pod. However I have not found the secret being used in the elasticsearch part at all. But: The elasticsearch section did not contain any credentials, so it might well be that the elasticsearch credential just isn't used at all?


#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Chart Version bumped
- [X] ~Upgrading instructions are documented in the README.md~ Not necessary, no code changes.
