### PR TITLE
elasticsearch-init also /opt/zammad/storage

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zammad
-version: 10.0.1
-appVersion: 6.1.0-22
+version: 10.0.2
+appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
 icon: https://raw.githubusercontent.com/zammad/zammad-documentation/main/images/zammad_logo_600x520.png

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.0.2
+version: 10.0.3
 appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.0.3
+version: 10.0.4
 appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -107,6 +107,8 @@ spec:
             - name: {{ template "zammad.fullname" . }}-tmp
               mountPath: /opt/zammad/tmp
             - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
+            - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
         - name: postgresql-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -148,6 +150,8 @@ spec:
               subPath: postgresql-init
             - name: {{ template "zammad.fullname" . }}-tmp
               mountPath: /opt/zammad/tmp
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
         {{- if .Values.zammadConfig.elasticsearch.initialisation }}

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -203,9 +203,9 @@ spec:
           - name: {{ template "zammad.fullname" . }}-tmp
             mountPath: /opt/zammad/tmp
           - name: {{ template "zammad.fullname" . }}-var
-            mountPath: /opt/zammad/var
-          - name: {{ template "zammad.fullname" . }}-var
             mountPath: /opt/zammad/storage
+          - name: {{ template "zammad.fullname" . }}-var
+            mountPath: /opt/zammad/var
         {{- end }}
       containers:
         {{- with .Values.sidecars }}

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -200,6 +200,8 @@ spec:
             mountPath: /opt/zammad/tmp
           - name: {{ template "zammad.fullname" . }}-var
             mountPath: /opt/zammad/var
+          - name: {{ template "zammad.fullname" . }}-var
+            mountPath: /opt/zammad/storage
         {{- end }}
       containers:
         {{- with .Values.sidecars }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -260,7 +260,7 @@ zammadConfig:
       enabled: true
       image:
         repository: alpine
-        tag: "3.18.3"
+        tag: "3.18.4"
         pullPolicy: IfNotPresent
       resources: {}
         # requests:


### PR DESCRIPTION
#### What this PR does / why we need it

After a restart zammad-0 -c elasticsearch-init had an error Read-only file system /opt/zammad/storage

> E, [2023-09-20T04:04:01.548417#9-6180] ERROR -- : Unable to send Ticket.find(290).search_index_update_backend backend: #<Errno::EROFS: Read-only file system @ dir_s_mkdir - /opt/zammad/storage>


this was already suggested in #214, which introduced `/opt/zammad/storage` in all containers _and_ all initContainers

But #214 was superseded by #215, which introduced `/opt/zammad/storage` only in all containers, but not in initContainers.

I am not sure if we need  `/opt/zammad/storage` in all initContainers, but for sure in elasticsearch-init.


#### Which issue this PR fixes

- fixes #212

#### Checklist


- [x] Chart Version bumped
- [ ] Upgrading instructions are documented in the README.md
