### PR TITLE
Update CI configuration to also test against k8s 1.28.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,10 +88,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.25.14
-          - v1.26.10
-          - v1.27.7
-          - v1.28.3
+          # Versions of kindest/node
+          - v1.25.11
+          - v1.26.6
+          - v1.27.3
+          - v1.28.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.25.11
-          - v1.26.6
-          - v1.27.3
+          - v1.25.14
+          - v1.26.10
+          - v1.27.7
+          - v1.28.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,9 +88,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.25.11
-          - v1.26.6
-          - v1.27.3
+          - v1.25.14
+          - v1.26.10
+          - v1.27.7
+          - v1.28.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
No chart changes, just CI updates.