### PR TITLE
fix persistence.enabled: false

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.0.4
+version: 10.0.5
 appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -451,9 +451,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "zammad.fullname" .) }}
   {{- else if not .Values.persistence.enabled }}
-      - name: {{ template "zammad.fullname" . }}-var
-        emptyDir:
-          sizeLimit: {{ .Values.persistence.size | quote }}
+        - name: {{ template "zammad.fullname" . }}-var
+          emptyDir:
+            sizeLimit: {{ .Values.persistence.size | quote }}
   {{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
When `persistence.enabled` value is set to `false`, due to wrong indentation Helm will fail with following error: `error converting YAML to JSON: yaml: line 402: did not find expected key`