### PR TITLE
Fixes: #234 - customInit: Can't find config setting

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.1.0
+version: 10.1.1
 appVersion: 6.1.0-24
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -5,21 +5,6 @@ metadata:
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
 data:
-{{ if .Values.zammadConfig.elasticsearch.initialisation }}
-  elasticsearch-init: |-
-    #!/bin/bash
-    set -e
-    bundle exec rails r 'Setting.set("es_url", "{{ .Values.zammadConfig.elasticsearch.schema }}://{{ if .Values.zammadConfig.elasticsearch.enabled }}{{ .Release.Name }}-elasticsearch{{ else }}{{ .Values.zammadConfig.elasticsearch.host }}{{ end }}:{{ .Values.zammadConfig.elasticsearch.port }}")'
-    ELASTICSEARCH_USER=${ELASTICSEARCH_USER:-{{ .Values.zammadConfig.elasticsearch.user }}}
-    if [ -n "${ELASTICSEARCH_USER}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
-        bundle exec rails r "Setting.set(\"es_user\", \"${ELASTICSEARCH_USER}\")"
-        bundle exec rails r "Setting.set(\"es_password\", \"${ELASTICSEARCH_PASSWORD}\")"
-    fi
-    {{- if and .Values.zammadConfig.elasticsearch.reindex }}
-    bundle exec rake zammad:searchindex:rebuild
-    {{ end }}
-    echo "elasticsearch init complete :)"
-{{ end }}
   postgresql-init: |-
     #!/bin/bash
     set -e
@@ -40,3 +25,18 @@ data:
         {{- . | nindent 4 }}
       {{- end }}
     echo "zammad init complete :)"
+{{ if .Values.zammadConfig.elasticsearch.initialisation }}
+  elasticsearch-init: |-
+    #!/bin/bash
+    set -e
+    bundle exec rails r 'Setting.set("es_url", "{{ .Values.zammadConfig.elasticsearch.schema }}://{{ if .Values.zammadConfig.elasticsearch.enabled }}{{ .Release.Name }}-elasticsearch{{ else }}{{ .Values.zammadConfig.elasticsearch.host }}{{ end }}:{{ .Values.zammadConfig.elasticsearch.port }}")'
+    ELASTICSEARCH_USER=${ELASTICSEARCH_USER:-{{ .Values.zammadConfig.elasticsearch.user }}}
+    if [ -n "${ELASTICSEARCH_USER}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
+        bundle exec rails r "Setting.set(\"es_user\", \"${ELASTICSEARCH_USER}\")"
+        bundle exec rails r "Setting.set(\"es_password\", \"${ELASTICSEARCH_PASSWORD}\")"
+    fi
+    {{- if and .Values.zammadConfig.elasticsearch.reindex }}
+    bundle exec rake zammad:searchindex:rebuild
+    {{ end }}
+    echo "elasticsearch init complete :)"
+{{ end }}

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -37,6 +37,6 @@ data:
         echo "${AUTOWIZARD_JSON}" | base64 -d > /opt/zammad/var/auto_wizard.json
     fi
       {{- with .Values.zammadConfig.initContainers.zammad.customInit }}
-        {{- toYaml . | nindent 4 }}
+        {{- . | nindent 4 }}
       {{- end }}
     echo "zammad init complete :)"

--- a/zammad/templates/statefulset.yaml
+++ b/zammad/templates/statefulset.yaml
@@ -66,50 +66,6 @@ spec:
             - name: {{ template "zammad.fullname" . }}-var
               mountPath: /opt/zammad/var
         {{- end }}
-        - name: zammad-init
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-          {{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "zammad.redisSecretName" . }}
-                  key: {{ .Values.secrets.redis.secretKey }}
-          {{- end }}
-            - name: MEMCACHE_SERVERS
-              value: "{{ if .Values.zammadConfig.memcached.enabled }}{{ .Release.Name }}-memcached{{ else }}{{ .Values.zammadConfig.memcached.host }}{{ end }}:{{ .Values.zammadConfig.memcached.port }}"
-            - name: REDIS_URL
-              value: "redis://:$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis-master{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
-          {{- if .Values.autoWizard.enabled }}
-            - name: AUTOWIZARD_JSON
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "zammad.autowizardSecretName" . }}
-                  key: {{ .Values.secrets.autowizard.secretKey }}
-          {{- end }}
-          {{- if .Values.extraEnv }}
-          {{- toYaml .Values.extraEnv | nindent 12 }}
-          {{- end }}
-          {{- with .Values.zammadConfig.initContainers.zammad.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.zammadConfig.initContainers.zammad.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: {{ template "zammad.fullname" . }}-init
-              mountPath: /docker-entrypoint.sh
-              readOnly: true
-              subPath: zammad-init
-            - name: {{ template "zammad.fullname" . }}-tmp
-              mountPath: /opt/zammad/tmp
-            - name: {{ template "zammad.fullname" . }}-var
-              mountPath: /opt/zammad/storage
-            - name: {{ template "zammad.fullname" . }}-var
-              mountPath: /opt/zammad/var
         - name: postgresql-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -148,6 +104,56 @@ spec:
               mountPath: /docker-entrypoint.sh
               readOnly: true
               subPath: postgresql-init
+            - name: {{ template "zammad.fullname" . }}-tmp
+              mountPath: /opt/zammad/tmp
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/storage
+            - name: {{ template "zammad.fullname" . }}-var
+              mountPath: /opt/zammad/var
+        - name: zammad-init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "zammad.redisSecretName" . }}
+                  key: {{ .Values.secrets.redis.secretKey }}
+          {{- end }}
+            - name: MEMCACHE_SERVERS
+              value: "{{ if .Values.zammadConfig.memcached.enabled }}{{ .Release.Name }}-memcached{{ else }}{{ .Values.zammadConfig.memcached.host }}{{ end }}:{{ .Values.zammadConfig.memcached.port }}"
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis-master{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
+            - name: POSTGRESQL_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "zammad.postgresqlSecretName" . }}
+                  key: {{ .Values.secrets.postgresql.secretKey }}
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.zammadConfig.postgresql.user }}:$(POSTGRESQL_PASS)@{{ if .Values.zammadConfig.postgresql.enabled }}{{ .Release.Name }}-postgresql{{ else }}{{ .Values.zammadConfig.postgresql.host }}{{ end }}:{{ .Values.zammadConfig.postgresql.port }}/{{ .Values.zammadConfig.postgresql.db }}"          {{- if .Values.autoWizard.enabled }}
+            - name: AUTOWIZARD_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "zammad.autowizardSecretName" . }}
+                  key: {{ .Values.secrets.autowizard.secretKey }}
+          {{- end }}
+          {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+          {{- with .Values.zammadConfig.initContainers.zammad.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.zammadConfig.initContainers.zammad.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "zammad.fullname" . }}-init
+              mountPath: /docker-entrypoint.sh
+              readOnly: true
+              subPath: zammad-init
             - name: {{ template "zammad.fullname" . }}-tmp
               mountPath: /opt/zammad/tmp
             - name: {{ template "zammad.fullname" . }}-var


### PR DESCRIPTION
#### Which issue this PR fixes

- fixes #234 

#### Special notes for your reviewer

- The solution was basically to first execute `postgresql-init`, and only then `zammad-init`, which also needed the database envs to be able to run Rails commands.
- toYaml seemed to break multiline statements, so I removed it - not entirely sure

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
