### PR TITLE
Switch to Zammad 6.2

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zammad
-version: 11.0.0
-appVersion: '6.2'
+version: 10.2.0
+appVersion: 6.2.0-1
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
 icon: https://raw.githubusercontent.com/zammad/zammad-documentation/main/images/zammad_logo_600x520.png

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -114,11 +114,6 @@ Open your browser on <http://localhost:8080>
 
 ## Upgrading
 
-### From chart version 10.x to 11.0.0
-
-- The chart refers to a floating Zammad image version `6.2` now, which will automatically receive patch level updates.
-- If you want to change this, you can change `image.tag` to refer to a certain commit and `image.pullPolicy` to `IfNotExists` in [values.yaml](values.yaml).
-
 ### From chart version 9.x to 10.0.0
 
 - all containers uses `readOnlyRootFilesystem: true` again

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -1,8 +1,15 @@
 image:
   repository: ghcr.io/zammad/zammad
-  # if not set appVersion field from Chart.yaml is used as default
+  # If not set, appVersion field from Chart.yaml is used as default.
+  # appVersion points to a fixed version. You are responsible to update this to newer patch level versions yourself.
+  # Alternatively, you can also use floating versions that will give you automatic updates:
+  # tag: "6.2"     # all patchlevel updates
+  # tag: "6"       # including minor updates
+  # tag: "latest"  # all updates of stable versions, including major
+  # tag: "develop" # bleeding-edge development version
+  # If you want to use a floating version, you should also set pullPolicy: Always
   tag: ""
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   imagePullSecrets: []
     # - name: "image-pull-secret"
 


### PR DESCRIPTION
#### What this PR does / why we need it

- Switches to Zammad 6.2
- This also switches from commit-level Zammad image reference to a floating value that will update within the minor release automatically. That's the recommended behaviour which is also active for package installations. It can still be changed locally.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Upgrading instructions are documented in the README.md
