### PR TITLE
Openshift owned tmp

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 10.2.0
+version: 10.2.1
 appVersion: 6.2.0-1
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -59,7 +59,7 @@ zammadConfig:
         runAsUser: null
       customInit: |
         # use an openshift uid owned /tmp for attachments upload
-        mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
+        mkdir -pv /opt/zammad/var/tmp && chmod -v +t /opt/zammad/var/tmp
   railsserver:
     tmpdir: "/opt/zammad/var/tmp"
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -57,21 +57,11 @@ zammadConfig:
     zammad:
       securityContext:
         runAsUser: null
+      customInit: |
+        # use an openshift uid owned /tmp for attachments upload
+        mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
   railsserver:
     tmpdir: "/opt/zammad/var/tmp"
-
-
-initContainers:
-  - name: railsserver-tmp-init
-    image: "alpine:3.18.2"
-    command:
-      - /bin/sh
-      - -cx
-      - |
-        mkdir -p /opt/zammad/var/tmp && chmod +t /opt/zammad/var/tmp
-    volumeMounts:
-      - name: zammad-var
-        mountPath: /opt/zammad/var
 
 elasticsearch:
   sysctlImage:


### PR DESCRIPTION
#### What this PR does / why we need it

remove initContainer (for openshift uid owned /tmp for attachments upload) and use customInit from #231 in examples


## Verbosity

I am not sure if this verbosity 37b5a3171d6b82bc4e3f9387fe3e97b5ea7d8c76 is appreciated, we can remove this as you like.


#### Checklist

- [x] Chart Version bumped, its not a functional, but documantary change
- [x] Upgrading instructions are documented in the zammad/README.md
