### PR TITLE
Allow customizing init job

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zammad
-version: 12.1.1
-appVersion: 6.3.1
+version: 12.2.0
+appVersion: 6.3.1-4
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org
 icon: https://raw.githubusercontent.com/zammad/zammad-documentation/main/images/zammad_logo_600x520.png

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -144,6 +144,19 @@ redis:
       enabled: false
 ```
 
+### Deploying with ArgoCD
+
+Due to the way Argo CD syncs Helm charts into the cluster and this chart deploying the initialization job, the default configuration can lead to Sync loops where Argo CD will create an infinite amount of initialization jobs.
+To prevent this, disable the random name for the initialization job and add the according annotation to the job to let Argo CD treat it as a Sync Hook.
+
+```yaml
+zammadConfig:
+  initJob:
+    randomName: false
+    annotations:
+      argocd.argoproj.io/hook: Sync
+```
+
 ## Upgrading
 
 ### From Chart Version 11.x to 12.0.0

--- a/zammad/templates/job-init.yaml
+++ b/zammad/templates/job-init.yaml
@@ -1,13 +1,21 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "zammad.fullname" . }}-init-{{ uuidv4 }}
+  {{- if .Values.zammadConfig.initJob.randomName }}
   # Use a different job name on each run to ensure a new job always runs once.
+  name: {{ include "zammad.fullname" . }}-init-{{ uuidv4 }}
+  {{- else }}
+  name: {{ include "zammad.fullname" . }}-init
+  {{- end}}
   # Helm post-install/post-upgrade hooks cannot be used here, because
   #   helm's --wait flag causes a deadlock: the job waits for all resources to be ready,
   #   but the pods need the job to work properly.
   labels:
     {{- include "zammad.labels" . | nindent 4 }}
+  {{- with .Values.zammadConfig.initJob.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   template:

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -354,6 +354,11 @@ zammadConfig:
       customInit: ""
         #  bundle exec rails runner '…'
 
+  initJob:
+    randomName: true
+    annotations: {}
+    # my-annotation: "value"
+
 # additional environment vars added to all zammad services
 extraEnv: []
   # - name: FOO_BAR


### PR DESCRIPTION
This change allows cusomizing the annotations on the init Job.

I use Argo CD to deploy this helm chart. Argo CD periodically checks the health of the application and applies the chart again in case of any inconsistency. Because the init Job is not a Helm hook, it is treated as a normal resource by Argo CD. When the job completes, it is deleted after 300 seconds, which causes Argo CD to recreate it, which then causes the job to run over and over again, causing the search to not be available sometimes because the index gets deleted and recreated.

With this change, I can declare the init Job as an Argo CD hook (which is less limited than the Helm counterparts) and disable the randomization of the Job name to make it not recreate the job indefinitely.

```yaml
initJob:
  randomName: false
  annotations:
    argocd.argoproj.io/hook: Sync
```

#### Checklist

- [x] Chart Version bumped
