### PR TITLE
Fix resource definitions

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 12.3.2
+version: 12.3.3
 appVersion: 6.3.1-121
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -480,6 +480,14 @@ elasticsearch:
     heapSize: 512m
     masterOnly: false
     replicaCount: 1
+    resources: {}
+      # requests:
+      #   cpu: 50m
+      #   memory: 512Mi
+      # limits:
+      #   cpu: 100m
+      #   memory: 1024Mi
+
   # To use an existing Kubernetes secret containing the credentials,
   # remove the comments on the lines below and adjust them accordingly
   #
@@ -535,13 +543,14 @@ postgresql:
     #   userPasswordKey: postgresql-pass
     #   replicationPasswordKey: postgresql-replication-password
     #
-  resources: {}
-    # requests:
-    #   cpu: 250m
-    #   memory: 256Mi
-    # limits:
-    #   cpu: 500m
-    #   memory: 512Mi
+  primary:
+    resources: {}
+      # requests:
+      #   cpu: 250m
+      #   memory: 256Mi
+      # limits:
+      #   cpu: 500m
+      #   memory: 512Mi
 
 # settings for the redis subchart
 redis:


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- The resource for postgres in values.yaml was invalid, as there's no top level `resource` key, but under `primary`: See https://github.com/bitnami/charts/blob/141e52fbb02909e3e9803319727e646a984f7bae/bitnami/postgresql/values.yaml#L481
- Add resources for elastic search.

#### Which issue this PR fixes

None

#### Special notes for your reviewer

None

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md
