### PR TITLE
add initJob.podSpec

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 12.4.1
+version: 12.4.2
 appVersion: 6.3.1-185
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 12.4.2
+version: 12.5.0
 appVersion: 6.3.1-185
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/ci/full-values.yaml
+++ b/zammad/ci/full-values.yaml
@@ -75,6 +75,8 @@ zammadConfig:
       my-initJob-pod-label: my-initJob-pod-label-value
     podAnnotations:
       my-initJob-pod-annotation: my-initJob-pod-annotation-value
+    podSpec:
+      activeDeadlineSeconds: 1337
 
 commonLabels:
   my-common-label: my-common-label-value
@@ -87,6 +89,3 @@ podLabels:
 
 podAnnotations:
   my-pod-annotation: my-pod-annotation-value
-
-podSpec:
-  activeDeadlineSeconds: 1337

--- a/zammad/ci/full-values.yaml
+++ b/zammad/ci/full-values.yaml
@@ -87,3 +87,6 @@ podLabels:
 
 podAnnotations:
   my-pod-annotation: my-pod-annotation-value
+
+podSpec:
+  activeDeadlineSeconds: 1337

--- a/zammad/templates/job-init.yaml
+++ b/zammad/templates/job-init.yaml
@@ -35,6 +35,9 @@ spec:
         {{- end }}
     spec:
       {{- include "zammad.podSpec" . | nindent 6 }}
+      {{- with .Values.zammadConfig.initJob.podSpec }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         {{- with .Values.initContainers }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -380,6 +380,8 @@ zammadConfig:
       # my-label: "value"
     podAnnotations: {}
     # my-annotation: "value"
+    podSpec: {}
+    # my-podspec: "value"
 
 # additional environment vars added to all zammad services
 extraEnv: []


### PR DESCRIPTION
#### What this PR does / why we need it

Adds podSpec to the [initJob](https://github.com/zammad/zammad-helm/blob/main/zammad/templates/job-init.yaml)

#### Which issue this PR fixes

With this PR I can add
 
```
  initJob:
    podSpec:
      activeDeadlineSeconds: 1337
```
and fix #297

#### Checklist

- [x] Chart Version bumped

