### PR TITLE
Use deployment strategy: Recreate for scheduler and websocket deployments to avoid coexisting replicas

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.0.9
+version: 13.0.10
 appVersion: 6.4.1-32
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/deployment-scheduler.yaml
+++ b/zammad/templates/deployment-scheduler.yaml
@@ -11,6 +11,8 @@ metadata:
     checkov.io/skip2: CKV_K8S_9=Readiness Probe Should be Configured - not possible with scheduler
 spec:
   replicas: 1 # Not scalable, may only run once per cluster.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}

--- a/zammad/templates/deployment-websocket.yaml
+++ b/zammad/templates/deployment-websocket.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- include "zammad.annotations" . | nindent 4 }}
 spec:
   replicas: 1 # Not scalable, may only run once per cluster.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it

Currently the [scheduler](https://github.com/zammad/zammad-helm/blob/main/zammad/templates/deployment-scheduler.yaml) is [RollingUpdate (it is the default value)](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). This leads to an small time period with 2 schedulers.

But the scheduler [may only run once per cluster.](https://github.com/zammad/zammad-helm/blob/main/zammad/templates/deployment-scheduler.yaml#L13).

Changing [deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) to `Recreate Deployment`

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md
