### PR TITLE
elasticsearch-init check on existing index before reindex 

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.0.11
+version: 14.0.0
 appVersion: 6.4.1-45
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -179,6 +179,10 @@ zammadConfig:
 
 ## Upgrading
 
+### From Chart Version 13.x to 14.0.0
+
+- The initcontainer `elasticsearch-init` only executes an ElasticSearch reindex if the index `Ticket` does not exist. The ElasticSearch reindex can also be forced with the new parameter `zammadConfig.elasticsearch.forceReinit`. The parameter `zammadConfig.elasticsearch.reindex` has therefore been removed.
+
 ### From Chart Version 12.x to 13.0.0
 
 - All subcharts received updates to the latest major version. Please refer to their upgrading instructions.

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -41,8 +41,12 @@ data:
         bundle exec rails r "Setting.set(\"es_user\", \"${ELASTICSEARCH_USER}\")"
         bundle exec rails r "Setting.set(\"es_password\", \"${ELASTICSEARCH_PASSWORD}\")"
     fi
-    {{- if and .Values.zammadConfig.elasticsearch.reindex }}
-    bundle exec rake zammad:searchindex:rebuild
-    {{ end }}
+    rails r "
+    require 'rake'
+    Zammad::Application.load_tasks
+    if !SearchIndexBackend.index_exists?('Ticket') || {{ .Values.zammadConfig.elasticsearch.forceReinit }}
+        Rake::Task['zammad:searchindex:rebuild'].invoke
+    end
+    "
     echo "elasticsearch init complete :)"
 {{ end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -73,7 +73,7 @@ zammadConfig:
     initialisation: true
     pass: ""
     port: 9200
-    reindex: true
+    forceReinit: false
     schema: http
     user: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it

The initcontainer `elasticsearch-init` only executes an ElasticSearch reindex if the index `Ticket` does not exist. The ElasticSearch reindex can also be forced with the new parameter `zammadConfig.elasticsearch.forceReinit`. The parameter `zammadConfig.elasticsearch.reindex` has therefore been removed.


#### Which issue this PR fixes

- fixes #319

#### Special notes for your reviewer

I had to expand `bundle exec rake zammad:searchindex:rebuild` into `rails r` to get access on SearchIndexBackend.

#### Checklist

- [x] Chart Version bumped
- [x] Upgrading instructions are documented in the zammad/README.md