### PR TITLE
 Turn off automatic reindexing by default, but reindex if no index is present yet.

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.2.0
+version: 14.0.0
 appVersion: 6.5.0
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -179,6 +179,13 @@ zammadConfig:
 
 ## Upgrading
 
+### From Chart Version 13.x to 14.0.0
+
+- The default value of `zammadConfig.elasticsearch.reindex` changed from `true` to `false`. This means that
+  with the default value, the chart will no longer reindex the elasticsearch content after every single
+  update, causing search results to be incomplete until the reindexing finished.
+- With the new default value of `false`, the Chart will still create an index on installation (if no index is present).
+
 ### From Chart Version 12.x to 13.0.0
 
 - All subcharts received updates to the latest major version. Please refer to their upgrading instructions.

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -183,8 +183,8 @@ zammadConfig:
 
 - The default value of `zammadConfig.elasticsearch.reindex` changed from `true` to `false`. This means that
   with the default value, the chart will no longer reindex the elasticsearch content after every single
-  update, causing search results to be incomplete until the reindexing finished.
-- With the new default value of `false`, the Chart will still create an index on installation (if no index is present).
+  update (which caused search results to be incomplete until the reindexing finished).
+- With the new default value of `false`, the chart will still create an index on installation (if no index is present).
 
 ### From Chart Version 12.x to 13.0.0
 

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -52,9 +52,18 @@ data:
         bundle exec rails r "Setting.set('es_user', '${ELASTICSEARCH_USER}'); Setting.set('es_password', '${ELASTICSEARCH_PASSWORD}')"
     fi
 
-    {{- if and .Values.zammadConfig.elasticsearch.reindex }}
+  {{ if .Values.zammadConfig.elasticsearch.reindex }}
     bundle exec rake zammad:searchindex:rebuild
-    {{ end }}
+  {{ else }}
+    echo "Checking if an elasticsearch index already exists…"
+    if bundle exec rails r "SearchIndexBackend.index_exists?('Ticket') || exit(1)"
+    then
+      echo "Elasticsearch index exists, no automatic reindexing is needed."
+    else
+      echo "Elasticsearch index does not exist yet, create it now…"
+      bundle exec rake zammad:searchindex:rebuild
+    fi
+  {{ end }}
 
     echo "elasticsearch init complete :)"
 {{ end }}

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -56,6 +56,10 @@ data:
     bundle exec rake zammad:searchindex:rebuild
   {{ else }}
     echo "Checking if an elasticsearch index already exists…"
+
+    # Ensure ES connectivity, as SearchIndexBackend.index_exists? swallows internal errors.
+    bundle exec rails r "SearchIndexBackend.version"
+
     if bundle exec rails r "SearchIndexBackend.index_exists?('Ticket') || exit(1)"
     then
       echo "Elasticsearch index exists, no automatic reindexing is needed."

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -73,7 +73,7 @@ zammadConfig:
     initialisation: true
     pass: ""
     port: 9200
-    reindex: true
+    reindex: false
     schema: http
     user: ""
 


### PR DESCRIPTION
#### Which issue this PR fixes

- fixes #319 

#### Special notes for your reviewer

- This does not introduce new variables, but changes default behaviour: Reindexing is not always forced now, but it happens when no index is present. This should be what most users want. It can be turned off via `zammadConfig.elasticsearch.initalization = false`
- Therefore I hope that a minor release is enough.

#### Checklist

- [x] Chart Version bumped
