### PR TITLE
remove nginx initialDelaySeconds

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.0.12
+version: 13.0.13
 appVersion: 6.4.1-45
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -113,7 +113,6 @@ zammadConfig:
       httpGet:
         path: /
         port: 8080
-      initialDelaySeconds: 30
       successThreshold: 1
       failureThreshold: 5
       timeoutSeconds: 5


### PR DESCRIPTION
#### What this PR does / why we need it

The [readiness-probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#readiness-probe) nginx delays accepting traffic for 30 seconds with [initialDelaySeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes), but nginx is ready after 1-2 seconds, this unnecessarily delays my deploy or restart.

The `initialDelaySeconds: 30` on the readiness-probe can make sense for rails, because rails needs about 30 seconds to accept traffic, but the readiness-probe checks on port 3000 anyway. 

## Additional changes

Currently I would also suggest

* remove`initialDelaySeconds: 30` on the readiness-probe, it checks on port 3000 anyway. 
* remove [successThreshold: 1](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) Default is already to 1
* remove [periodSeconds: 10](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) Default is already to 10

#### Checklist

- [x] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md
