### PR TITLE
Serialize container execution in init job for minimal resource usage

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.0.13
+version: 13.1.0
 appVersion: 6.4.1-64
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/configmap-init.yaml
+++ b/zammad/templates/configmap-init.yaml
@@ -22,6 +22,14 @@ data:
     fi
 
     echo "postgresql init complete :)"
+  postgresql-init-post: |-
+    #!/bin/bash
+    set -e
+
+    # Run a rails command to ensure the database is up and running.
+    bundle exec rails r "true"
+
+    echo "init sequence complete :)"
   zammad-init: |-
     #!/bin/bash
     set -e

--- a/zammad/templates/job-init.yaml
+++ b/zammad/templates/job-init.yaml
@@ -39,7 +39,7 @@ spec:
       {{- toYaml . | nindent 6}}
       {{- end }}
       restartPolicy: OnFailure
-      containers:
+      initContainers:
         {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8}}
         {{- end }}
@@ -103,6 +103,18 @@ spec:
               readOnly: true
               subPath: elasticsearch-init
         {{- end }}
+      containers:
+        - name: postgresql-init-post
+          {{- include "zammad.containerSpec" (merge (dict "containerConfig" .Values.zammadConfig.initContainers.postgresql) .) | nindent 10 }}
+          env:
+            {{- include "zammad.env" . | nindent 12 }}
+            {{- include "zammad.env.failOnPendingMigrations" . | nindent 12 }}
+          volumeMounts:
+            {{- include "zammad.volumeMounts" . | nindent 12 }}
+            - name: {{ include "zammad.fullname" . }}-init
+              mountPath: /docker-entrypoint.sh
+              readOnly: true
+              subPath: postgresql-init-post
       volumes:
         {{- include "zammad.volumes" . | nindent 8 }}
         - name: {{ include "zammad.fullname" . }}-init


### PR DESCRIPTION
#### Which issue this PR fixes

- fixes #322 

#### Special notes for your reviewer

I decided for the `initContainer` based serial approach as it has the smallest resource footprint due to serial execution. There is now a new `postgresql-init-post` container which is only there because a job cannot have only `initContainers` and the number of these is dynamic depending on the configuration.

#### Checklist

- [x] Chart Version bumped
