### PR TITLE
Add nodeSelector, tolerations and affinity configuration on the component level

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 13.1.1
+version: 13.1.2
 appVersion: 6.4.1-64
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/deployment-nginx.yaml
+++ b/zammad/templates/deployment-nginx.yaml
@@ -27,6 +27,18 @@ spec:
         {{- end }}
     spec:
       {{- include "zammad.podSpec.deployment" . | nindent 6 }}
+      {{- with .Values.zammadConfig.nginx.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.nginx.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.nginx.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         {{- with .Values.zammadConfig.nginx.sidecars }}
         {{- toYaml . | nindent 8}}

--- a/zammad/templates/deployment-railsserver.yaml
+++ b/zammad/templates/deployment-railsserver.yaml
@@ -27,6 +27,18 @@ spec:
         {{- end }}
     spec:
       {{- include "zammad.podSpec.deployment" . | nindent 6 }}
+      {{- with .Values.zammadConfig.railsserver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.railsserver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.railsserver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         {{- with .Values.zammadConfig.railsserver.sidecars }}
         {{- toYaml . | nindent 8}}

--- a/zammad/templates/deployment-scheduler.yaml
+++ b/zammad/templates/deployment-scheduler.yaml
@@ -31,6 +31,18 @@ spec:
         {{- end }}
     spec:
       {{- include "zammad.podSpec.deployment" . | nindent 6 }}
+      {{- with .Values.zammadConfig.scheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.scheduler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.scheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         {{- with .Values.zammadConfig.scheduler.sidecars }}
         {{- toYaml . | nindent 8}}

--- a/zammad/templates/job-init.yaml
+++ b/zammad/templates/job-init.yaml
@@ -38,6 +38,18 @@ spec:
       {{- with .Values.zammadConfig.initJob.podSpec }}
       {{- toYaml . | nindent 6}}
       {{- end }}
+      {{- with .Values.zammadConfig.initJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.initJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.zammadConfig.initJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       initContainers:
         {{- with .Values.initContainers }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -137,6 +137,30 @@ zammadConfig:
       # my-label: "value"
     podAnnotations: {}
       # my-annotation: "value"
+    nodeSelector: {}
+      # node-label: "value"
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: "node-label"
+      #             operator: In
+      #             values:
+      #               - "value"
+      # podAntiAffinity:
+      #   preferredDuringSchedulingIgnoredDuringExecution:
+      #     - weight: 100
+      #       podAffinityTerm:
+      #         topologyKey: kubernetes.io/hostname # For host anti-affinity
+      #         labelSelector:
+      #           matchLabels:
+      #             app.kubernetes.io/component: zammad-nginx
 
   postgresql:
     # enable/disable postgresql chart dependency
@@ -194,7 +218,30 @@ zammadConfig:
     podLabels: {}
       # my-label: "value"
     podAnnotations: {}
-      # my-annotation: "value"
+    nodeSelector: {}
+      # node-label: "value"
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: "node-label"
+      #             operator: In
+      #             values:
+      #               - "value"
+      # podAntiAffinity:
+      #   preferredDuringSchedulingIgnoredDuringExecution:
+      #     - weight: 100
+      #       podAffinityTerm:
+      #         topologyKey: kubernetes.io/hostname # For host anti-affinity
+      #         labelSelector:
+      #           matchLabels:
+      #             app.kubernetes.io/component: zammad-railsserver
 
   redis:
     # enable/disable redis chart dependency
@@ -225,6 +272,22 @@ zammadConfig:
       # my-label: "value"
     podAnnotations: {}
       # my-annotation: "value"
+    nodeSelector: {}
+      # node-label: "value"
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: "node-label"
+      #             operator: In
+      #             values:
+      #               - "value"
 
   storageVolume:
     # Enable this for 'File' based storage in Zammad. You must provide an externally managed 'extistingClaim'
@@ -292,6 +355,22 @@ zammadConfig:
       # my-label: "value"
     podAnnotations: {}
       # my-annotation: "value"
+    nodeSelector: {}
+      # node-label: "value"
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: "node-label"
+      #             operator: In
+      #             values:
+      #               - "value"
 
   initContainers:
     elasticsearch:
@@ -381,6 +460,22 @@ zammadConfig:
     # my-annotation: "value"
     podSpec: {}
     # my-podspec: "value"
+    nodeSelector: {}
+      # node-label: "value"
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: "node-label"
+      #             operator: In
+      #             values:
+      #               - "value"
 
 # additional environment vars added to all zammad services
 extraEnv: []
@@ -434,9 +529,27 @@ podLabels: {}
 podAnnotations: {}
   # my-annotation: "value"
 
+# Common pod nodeSelector for all Zammad components. Values in .Zammad.*.nodeSelector will override this.
 nodeSelector: {}
+  # node-label: "value"
+
+# Common pod tolerations for all Zammad components. Values in .Zammad.*.tolerations will override this.
 tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+# Common pod affinity for all Zammad components. Values in .Zammad.*.affinity will override this.
 affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #           - key: "node-label"
+  #             operator: In
+  #             values:
+  #               - "value"
 
 # service account configurations
 serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Adds additional configuration on the component level like nginx and railsserver deployments/pods

Let's say we have use case:

1. 2x k8s worker nodes
2. 2x nginx replicas
3. 2x railsserver replicas

With current release you are unable to set the podAntiAffinity rules to have 1x nginx and 1x railsserver on Node 1, and other 2 pods one Node 2
 

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Chart Version bumped
