### PR TITLE
add support for http 1.1 in the nginx config

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 14.1.2
+version: 14.1.3
 appVersion: 6.5.0-75
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/configmap-nginx.yaml
+++ b/zammad/templates/configmap-nginx.yaml
@@ -91,6 +91,7 @@ data:
         }
 
         location / {
+            proxy_http_version 1.1;
             {{- if .Values.zammadConfig.nginx.knowledgeBaseUrl }}
             proxy_set_header X-ORIGINAL-URL $request_uri;
             {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- This PR sets `proxy_http_version 1.1` in the `location /` block of the NGINX ConfigMap to ensure consistency with other location blocks (e.g., `/cable` and `/ws`) that already specify HTTP/1.1.

- This change is necessary to support integration with services that require HTTP/1.1, such as when deploying Zammad in environments like Istio-based service meshes. Without this, the default fallback to HTTP/1.0 can cause compatibility issues.

#### Special notes for your reviewer

- This was discussed in the [Zammad development community forum](https://community.zammad.org/t/http-1-1-support-for-the-nginx-location-block/17759) 

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
