### PR TITLE
fix: deployment selectors missing component label

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 14.1.5
+version: 15.0.0
 appVersion: 6.5.0-101
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 14.1.3
+version: 14.1.4
 appVersion: 6.5.0-75
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 14.1.4
+version: 14.1.5
 appVersion: 6.5.0-101
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -198,6 +198,12 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 
 ## Upgrading
 
+### From Chart Version 14.x to 15.0.0
+
+- The selector labels of all deployments changed which are unfortunately immutable. This means each deployment needs to 
+  be deleted before upgrading the helm chart. To preserver high availability the `cascade=orphan` option can be used 
+  (e.g. `kubectl/oc delete deployment --selector app.kubernetes.io/name=zammad --cascade=orphan`).
+
 ### From Chart Version 13.x to 14.0.0
 
 - The default value of `zammadConfig.elasticsearch.reindex` changed from `true` to `false`. This means that

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -200,8 +200,8 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 
 ### From Chart Version 14.x to 15.0.0
 
-- The selector labels of all deployments changed which are unfortunately immutable. This means each deployment needs to 
-  be deleted before upgrading the helm chart. To preserver high availability the `cascade=orphan` option can be used 
+- The selector labels of all deployments changed which are unfortunately immutable. This means each deployment needs to  
+  be deleted before upgrading the helm chart. To preserver high availability the `cascade=orphan` option can be used  
   (e.g. `kubectl/oc delete deployment --selector app.kubernetes.io/name=zammad --cascade=orphan`).
 
 ### From Chart Version 13.x to 14.0.0

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -201,7 +201,7 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 ### From Chart Version 14.x to 15.0.0
 
 - The selector matchLabels of all deployments changed which are unfortunately immutable. This means each deployment needs to  
-  be deleted before upgrading the helm chart. To preserver high availability the `cascade=orphan` option can be used  
+  be deleted before upgrading the helm chart. To preserve high availability the `cascade=orphan` option can be used  
   (e.g. `kubectl/oc delete deployment --selector app.kubernetes.io/name=zammad --cascade=orphan`).
 
 ### From Chart Version 13.x to 14.0.0

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -200,7 +200,7 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 
 ### From Chart Version 14.x to 15.0.0
 
-- The selector labels of all deployments changed which are unfortunately immutable. This means each deployment needs to  
+- The selector matchLabels of all deployments changed which are unfortunately immutable. This means each deployment needs to  
   be deleted before upgrading the helm chart. To preserver high availability the `cascade=orphan` option can be used  
   (e.g. `kubectl/oc delete deployment --selector app.kubernetes.io/name=zammad --cascade=orphan`).
 

--- a/zammad/templates/deployment-nginx.yaml
+++ b/zammad/templates/deployment-nginx.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-nginx
   template:
     metadata:
       annotations:

--- a/zammad/templates/deployment-railsserver.yaml
+++ b/zammad/templates/deployment-railsserver.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-railsserver
   template:
     metadata:
       annotations:

--- a/zammad/templates/deployment-scheduler.yaml
+++ b/zammad/templates/deployment-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-scheduler
   template:
     metadata:
       annotations:

--- a/zammad/templates/deployment-websocket.yaml
+++ b/zammad/templates/deployment-websocket.yaml
@@ -14,6 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "zammad.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-websocket
   template:
     metadata:
       annotations:


### PR DESCRIPTION
<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Fix deployment selectors not unique for one deployment but only for one instance, which leads to pods showing up under wrong deployments

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, …)` format, will close that issue when PR gets merged)*

- fixes #349 

#### Special notes for your reviewer

- .

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Upgrading instructions are documented in the zammad/README.md
