### PR TITLE
fix:bitnamilegacy-elastic-sysctlImage

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 15.2.0
+version: 15.2.1
 appVersion: 6.5.1
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -652,10 +652,11 @@ elasticsearch:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/elasticsearch
+  sysctlImage:
+    repository: bitnamilegacy/os-shell
   global:
     security:
       allowInsecureImages: true
-
   clusterName: zammad
   coordinating:
     replicaCount: 0

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -657,6 +657,7 @@ elasticsearch:
   global:
     security:
       allowInsecureImages: true
+
   clusterName: zammad
   coordinating:
     replicaCount: 0


### PR DESCRIPTION

#### What this PR does / why we need it

-  Update the Elastic chart default configuration to include the bitnamilegacy sysctlImage

#### Which issue this PR fixes

- All default components that include the Zammad deployment are referencing bitnamilegacy. There was one leftover in the Elastic config, which this PR fixes


#### Checklist


- [x] Chart Version bumped
