### PR TITLE
Add support for Redis Sentinel

### DIFF
--- a/zammad/ci/full-values.yaml
+++ b/zammad/ci/full-values.yaml
@@ -34,6 +34,9 @@ redis:
   auth:
     existingSecret: redis-existing-secret
     existingSecretPasswordKey: redis-password
+  sentinel:
+    enabled: true
+  architecture: replication
 
 zammadConfig:
   storageVolume:
@@ -60,6 +63,9 @@ zammadConfig:
       my-railsserver-pod-label: my-railsserver-pod-label-value
     podAnnotations:
       my-railsserver-pod-annotation: my-railsserver-pod-annotation-value
+  redis:
+    sentinel:
+      enabled: true
   scheduler:
     podLabels:
       my-scheduler-pod-label: my-scheduler-pod-label-value

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -139,6 +139,17 @@ redis secret name
 {{- end -}}
 
 {{/*
+redis sentinel secret name
+*/}}
+{{- define "zammad.redisSentinelSecretName" -}}
+{{- if .Values.secrets.redis.sentinel.useExisting -}}
+{{ .Values.secrets.redis.sentinel.secretName }}
+{{- else -}}
+{{ include "zammad.fullname" . }}-{{ .Values.secrets.redis.sentinel.secretName }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 S3 access URL
 */}}
 {{- define "zammad.env.S3_URL" -}}
@@ -169,22 +180,53 @@ S3 access URL
 {{- end -}}
 
 {{/*
-environment variables for the Zammad Rails stack
+Redis Variables
 */}}
-{{- define "zammad.env" -}}
-{{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting -}}
+{{- define "zammad.env.redisVariables" -}}
+{{- if .Values.zammadConfig.redis.sentinel.username }}
+- name: REDIS_USERNAME
+  value: "{{ .Values.zammadConfig.redis.username }}"
+{{- end }}
+{{- if or .Values.zammadConfig.redis.pass .Values.secrets.redis.useExisting }}
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "zammad.redisSecretName" . }}
       key: {{ .Values.secrets.redis.secretKey }}
 {{- end }}
+# sentinel
+{{- if .Values.zammadConfig.redis.sentinel.enabled }}
+- name: REDIS_SENTINELS
+  value: "{{ join "," .Values.zammadConfig.redis.sentinel.sentinels }}"
+- name: REDIS_SENTINEL_NAME
+  value: "{{ .Values.zammadConfig.redis.sentinel.masterName | default "mymaster" }}"
+{{- if .Values.zammadConfig.redis.sentinel.username }}
+- name: REDIS_SENTINEL_USERNAME
+  value: "{{ .Values.zammadConfig.redis.sentinel.username }}"
+{{- end }}
+{{- if or .Values.zammadConfig.redis.sentinel.pass .Values.secrets.redis.useExisting }}
+- name: REDIS_SENTINEL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "zammad.redisSentinelSecretName" . }}
+      key: {{ .Values.secrets.redis.sentinel.secretKey }}
+{{- end }}
+{{- else }}
+# standalone
+- name: REDIS_URL
+  value: "redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis-master{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
+{{- end }}
+{{- end }}
+
+{{/*
+environment variables for the Zammad Rails stack
+*/}}
+{{- define "zammad.env" -}}
+{{ include "zammad.env.redisVariables" . }}
 - name: MEMCACHE_SERVERS
   value: "{{ if .Values.zammadConfig.memcached.enabled }}{{ .Release.Name }}-memcached{{ else }}{{ .Values.zammadConfig.memcached.host }}{{ end }}:{{ .Values.zammadConfig.memcached.port }}"
 - name: RAILS_TRUSTED_PROXIES
   value: "{{ .Values.zammadConfig.railsserver.trustedProxies }}"
-- name: REDIS_URL
-  value: "redis://:$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis-master{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
 - name: POSTGRESQL_PASS
   valueFrom:
     secretKeyRef:

--- a/zammad/templates/secrets.yaml
+++ b/zammad/templates/secrets.yaml
@@ -53,3 +53,20 @@ type: Opaque
 data:
   {{ .Values.secrets.redis.secretKey }}: {{ .Values.zammadConfig.redis.pass | b64enc | quote }}
 {{ end }}
+
+{{ if and .Values.zammadConfig.redis.sentinel.enabled }}
+{{ if and .Values.zammadConfig.redis.sentinel.pass (not .Values.secrets.redis.sentinel.useExisting) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "zammad.redisSentinelSecretName" . }}
+  labels:
+    {{- include "zammad.labels" . | nindent 4 }}
+  annotations:
+    {{- include "zammad.annotations" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.secrets.redis.sentinel.secretKey }}: {{ .Values.zammadConfig.redis.sentinel.pass | b64enc | quote }}
+{{ end }}
+{{ end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -53,6 +53,10 @@ secrets:
     useExisting: false
     secretKey: redis-password
     secretName: redis-pass
+    sentinel:
+      useExisting: false
+      secretKey: redis-sentinel-password
+      secretName: redis-sentinel-pass
 
 securityContext:
   fsGroup: 1000
@@ -264,7 +268,16 @@ zammadConfig:
     host: "zammad-redis-master"
     # needs to be the same as the redis.auth.password
     pass: zammad
+    username: # leave empty if no username is required
     port: 6379
+
+    sentinel:
+      enabled: false  # set to true to enable Redis Sentinel
+      sentinels:
+      - zammad-redis
+      masterName: mymaster
+      pass: zammad
+      username: # leave empty if no username is required
 
   scheduler:
     resources: {}
@@ -768,11 +781,15 @@ redis:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/redis
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+    enabled: false # set to true to enable Redis Sentinel
   global:
     security:
       allowInsecureImages: true
 
-  architecture: standalone
+  architecture: standalone  # set to 'replication' to use Redis Sentinel
   auth:
     password: zammad
     # To avoid passwords in your values.yaml, you can comment out the line above


### PR DESCRIPTION
#### What this PR does / why we need it

- Zammad 7.0 will bring support for Redis Sentinel. This PR is supposed to integrate it with the Helm chart.

#### Checklist

- [x] Chart Version bumped
