### PR TITLE
fix:Switch all images to bitnamilegacy

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 15.2.3
+version: 15.2.4
 appVersion: 6.5.2
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -654,6 +654,12 @@ elasticsearch:
     repository: bitnamilegacy/elasticsearch
   sysctlImage:
     repository: bitnamilegacy/os-shell
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/elasticsearch-exporter
   global:
     security:
       allowInsecureImages: true
@@ -689,6 +695,12 @@ memcached:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/memcached
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/memcached-exporter
   global:
     security:
       allowInsecureImages: true
@@ -707,9 +719,18 @@ minio:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/minio
+  clientImage:
+    repository: bitnamilegacy/minio-client
   global:
     security:
       allowInsecureImages: true
+  defaultInitContainers:
+    volumePermissions:
+      image:
+        repository: bitnamilegacy/os-shell
+  console:
+    image:
+      repository: bitnamilegacy/minio-object-browser
 
   auth:
     rootUser: zammadadmin
@@ -730,6 +751,12 @@ postgresql:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   global:
     security:
       allowInsecureImages: true
@@ -768,6 +795,21 @@ redis:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/redis
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+  kubectl:
+    image:
+      repository: bitnamilegacy/kubectl
+  sysctl:
+    image:
+      repository: bitnamilegacy/os-shell
   global:
     security:
       allowInsecureImages: true


### PR DESCRIPTION
#### What this PR does / why we need it

- This PR aims to complete the previous work on switching to bitnamilegacy repositories (https://github.com/zammad/zammad-helm/pull/354 and https://github.com/zammad/zammad-helm/pull/357)
- This gives complete functionalities for any dependencies of zammad helm chart to users

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
