### PR TITLE
Add appProtocol in zammad-nginx service

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.0.7
+version: 16.0.8
 appVersion: 7.0.0-0058
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.0.9
+version: 16.0.10
 appVersion: 7.0.1-0000
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.0.6
+version: 16.0.7
 appVersion: 7.0.0-0043
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/service-nginx.yaml
+++ b/zammad/templates/service-nginx.yaml
@@ -14,6 +14,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      appProtocol: {{ .Values.service.appProtocol }}
   selector:
     {{- include "zammad.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: zammad-nginx

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -16,6 +16,7 @@ image:
 service:
   type: ClusterIP
   port: 8080
+  appProtocol: kubernetes.io/ws
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it
I have been migrating away from ingress-nginx and started looking into using the Gateway API. After doing some tests with [kgateway](https://kgateway.dev/) I found that by default websockets are not working / enabled.

In [GEP-1911](https://gateway-api.sigs.k8s.io/geps/gep-1911/) it is explained that some Gateway API implementations do not support automatic protocol selection or require an explicit opt-in. I added the appProtocol as described in the linked documentation page, tested the changes on my cluster and found it to be working afterwards. 

#### Special notes for your reviewer
I was not sure whether to add to inline the value or add it to the `values.yaml`.

#### Checklist

- [x] Chart Version bumped