### PR TITLE
support HTTPRoute and ListenerSet

### DIFF
--- a/zammad/templates/httpRoute.yaml
+++ b/zammad/templates/httpRoute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "zammad.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zammad.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "zammad.annotations" . | nindent 4 }}
+    {{- with .Values.httpRoute.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.listenerSet.enabled }}
+    - kind: ListenerSet
+      name: {{ $fullName }}
+      namespace: {{ .Release.Namespace }}
+    {{- end }}
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName}}-nginx
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/zammad/templates/listenerSet.yaml
+++ b/zammad/templates/listenerSet.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.listenerSet.enabled -}}
+{{- $fullName := include "zammad.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zammad.labels" . | nindent 4 }}
+    {{- with .Values.listenerSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "zammad.annotations" . | nindent 4 }}
+    {{- with .Values.listenerSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  parentRef:
+    {{- with .Values.listenerSet.parentRef }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.listenerSet.listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -35,6 +35,50 @@ ingress:
     #     - chart-example.local
   labels: {}
 
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+  # When .Values.listenerSet.enabled is true, the listenerSet is used as the parent
+  # - name: gateway
+  #   sectionName: http
+  #   namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+
+# -- Expose the service via gateway-api ListenerSet
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+listenerSet:
+  enabled: false
+  annotations: {}
+  parentRef:
+    # name: gateway
+    # namespace: default
+  # Hostnames matching HTTP header.
+  listeners:
+    - name: http
+      hostname: chart-example.local
+      port: 80
+      protocol: HTTP
+    # - name: https
+    #   hostname: chart-example.local
+    #   port: 443
+    #   protocol: HTTPS
+    #   tls:
+    #     mode: Terminate
+    #     certificateRefs:
+    #       - name: chart-example-tls
 
 # Please note that passwords for PostgreSQL, Redis and S3 may not
 #   contain special characters which would require URL encoding.


### PR DESCRIPTION
*Work in progress; feedback is welcome*

<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Gateway API has become the de facto standard for Kubernetes ingress and traffic management. To stay aligned with current best practices and ecosystem direction, the Helm chart should add support for HTTPRoute and ListenerSet resources.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, …)` format, will close that issue when PR gets merged)*

- n/a

#### Special notes for your reviewer

-  n/a

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md
