### PR TITLE
feat: add support for TLS protocol to Redis connection (rediss://)

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.0.14
+version: 16.0.15
 appVersion: 7.0.1-0031
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.0.15
+version: 16.1.0
 appVersion: 7.0.1-0031
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -225,7 +225,7 @@ Redis Variables
 {{- else }}
 # standalone
 - name: REDIS_URL
-  value: "redis://{{ .Values.zammadConfig.redis.username }}:$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
+  value: "redis{{ if .Values.zammadConfig.redis.tls }}s{{ end }}://{{ .Values.zammadConfig.redis.username }}:$(REDIS_PASSWORD)@{{ if .Values.zammadConfig.redis.enabled }}{{ .Release.Name }}-redis{{ else }}{{ .Values.zammadConfig.redis.host }}{{ end }}:{{ .Values.zammadConfig.redis.port }}"
 {{- end }}
 {{- end }}
 

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -285,6 +285,8 @@ zammadConfig:
     username:
     # needs to be the same as the redis.auth.password
     pass: zammad
+    # set to true to use rediss:// schema (TLS)
+    tls: false
 
     sentinel:
       enabled: false  # set to true to enable Redis Sentinel


### PR DESCRIPTION
#### What this PR does / why we need it

- Introduces a `tls` configuration option under `zammadConfig.redis` (defaulting to `false` for backwards compatibility).
- Updates the `REDIS_URL` in `_helpers.tpl` to dynamically use the `rediss://` protocol schema when TLS is enabled, instead of hardcoding `redis://`.
- This fixes connectivity issues and enables native SSL/TLS connections when connecting Zammad to external Redis instances, or configuring Redis subchart to use TLS/SSL.

#### Special notes for your reviewer

- Helm template generation was tested locally and correctly provisions `rediss://` only when `tls: true`.

#### Checklist

- [x] Chart Version bumped
