### PR TITLE
Update fsGroupChangePolicy default on values.yaml

### DIFF
--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -68,7 +68,7 @@ secrets:
 securityContext:
   fsGroup: 1000
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods
-  fsGroupChangePolicy: Always
+  fsGroupChangePolicy: OnRootMismatch
   runAsUser: 1000
   runAsNonRoot: true
   runAsGroup: 1000


### PR DESCRIPTION
#### What this PR does / why we need it

- Changes `securityContext.fsGroupChangePolicy` default value to `OnRootMismatch`, to avoid very long start time when (big) volumes with big amount of files are used.

#### Which issue this PR fixes

- fixes #378