### PR TITLE
feat: add Pod Disruption Budget support

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.1.1
+version: 16.1.2
 appVersion: 7.0.1-0039
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.1.2
+version: 16.2.0
 appVersion: 7.0.1-0039
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/ci/full-values.yaml
+++ b/zammad/ci/full-values.yaml
@@ -100,3 +100,7 @@ podLabels:
 
 podAnnotations:
   my-pod-annotation: my-pod-annotation-value
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1

--- a/zammad/templates/pdb.yaml
+++ b/zammad/templates/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $components := list "nginx" "railsserver" "scheduler" "websocket" }}
+{{- range $component := $components }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "zammad.fullname" $ }}-{{ $component }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "zammad.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: zammad-{{ $component }}
+  annotations:
+    {{- include "zammad.annotations" $ | nindent 4 }}
+spec:
+  {{- with $.Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with $.Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "zammad.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: zammad-{{ $component }}
+{{- end }}
+{{- end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -75,6 +75,14 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+podDisruptionBudget:
+  enabled: false
+  # Specify either minAvailable or maxUnavailable, not both.
+  # Note: scheduler and websocket are not horizontally scalable (always 1 replica).
+  # Use maxUnavailable: 1 to avoid blocking node drains on those components.
+  minAvailable: ""
+  maxUnavailable: ""
+
 zammadConfig:
   elasticsearch:
     # enable/disable elasticsearch chart dependency


### PR DESCRIPTION
- Add podDisruptionBudget config to root level of values.yaml (disabled by default)
- Create pdb.yaml template that generates PDB for all 4 app components
- Use maxUnavailable: 1 to handle single-replica services gracefully
- Enable PDB in CI test values and production deployment
- Allows coordinated pod eviction during node maintenance/upgrades

<!--
Thank you for contributing to zammad/zammad-helm. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://helm.sh/docs/chart_best_practices/

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a Github
Action will run across your changes and do some initial checks and linting. These checks
run very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

-  Allows configuring PodDisruptionBudget

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, …)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

- .

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md
