### PR TITLE
Redis sentinel sentinels k8s-service

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.4.2
+version: 16.4.3
 appVersion: 7.1.0-0017
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 16.4.1
+version: 16.4.2
 appVersion: 7.1.0-0001
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -204,11 +204,7 @@ Redis Variables
 # sentinel
 {{- if .Values.zammadConfig.redis.sentinel.enabled }}
 - name: REDIS_SENTINELS
-{{- if .Values.zammadConfig.redis.enabled }}
-  value: "{{ .Release.Name }}-redis"
-{{- else }}
   value: "{{ join "," .Values.zammadConfig.redis.sentinel.sentinels }}"
-{{- end }}
 - name: REDIS_SENTINEL_NAME
   value: "{{ .Values.zammadConfig.redis.sentinel.masterName | default "mymaster" }}"
 {{- if .Values.zammadConfig.redis.sentinel.username }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -299,7 +299,7 @@ zammadConfig:
     sentinel:
       enabled: false  # set to true to enable Redis Sentinel
       sentinels:
-      - zammad-redis:26379
+      - zammad-redis-sentinel:26379
       masterName: mymaster
       # leave empty if no username is required
       username:


### PR DESCRIPTION
#### What this PR does / why we need it

Removes the switch to use the vanilla k8s-service as "sentinels" when sentinel is activated.

* if redis was enabled, what is mandatory for redis-sentinel, the else (with the configurable "sentinels") could never be used.
* if you want to use sentinel, there is no reason to use the vanilla not-sentinel "sentinels"

#### Checklist



- [x] Chart Version bumped
- [ ] Upgrading instructions are documented in the zammad/README.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Redis Sentinel connectivity by consistently using the configured Sentinel endpoint.
  - Updated the default Redis Sentinel address to support reliable service discovery.

- **Chores**
  - Bumped the Helm chart version from 16.4.2 to 16.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->