### PR TITLE
Maintenance: document helm 4 workaround and activate the upgrade: true flag for chart-testing

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,7 +5,7 @@ chart-repos:
   - elastic=https://helm.elastic.co
 check-version-increment: true
 debug: true
-# upgrade: true # Causes issues because of low performance on default GitHub actions servers.
+upgrade: true
 target-branch: main
 namespace: zammad
 release-label: zammad

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -6,6 +6,8 @@ chart-repos:
 check-version-increment: true
 debug: true
 upgrade: true
+# Needed because of CI splits value to its own job, so that default can be missing.
+skip-missing-values: true
 target-branch: main
 namespace: zammad
 release-label: zammad

--- a/.github/helm-force-conflicts-wrapper.sh
+++ b/.github/helm-force-conflicts-wrapper.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Shadows the real `helm` binary on PATH during `ct install` to
+#   strip `--force-conflicts` for subcommands that don't understand it.
+#
+# Helm 4 defaults to Server-Side Apply, which conflicts with fields (e.g.
+# .spec.nodeSets) the ECK operator takes ownership of after install, so
+# `helm upgrade` needs --force-conflicts. But chart-testing's
+# --helm-extra-args is passed to every helm subcommand it runs (install,
+# upgrade, test, uninstall), and --force-conflicts is only accepted by
+# install/upgrade/rollback - ct has no way to scope it per subcommand
+# (helm/chart-testing#540, closed as not_planned). This wrapper strips
+# --force-conflicts for any subcommand that doesn't understand it, so it can
+# stay in --helm-extra-args without breaking `helm test`/`helm uninstall`.
+# Remove once chart-testing supports per-subcommand extra args.
+#
+# Expects $REAL_HELM to point at the actual helm binary.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+case "${1:-}" in
+  install | upgrade | rollback)
+    exec "${REAL_HELM}" "$@"
+    ;;
+  *)
+    args=()
+    for arg in "$@"; do
+      [[ "${arg}" == "--force-conflicts" ]] || args+=("${arg}")
+    done
+    exec "${REAL_HELM}" "${args[@]}"
+    ;;
+esac

--- a/.github/helm-force-conflicts-wrapper.sh
+++ b/.github/helm-force-conflicts-wrapper.sh
@@ -21,7 +21,36 @@ set -o pipefail
 
 : "${REAL_HELM:?REAL_HELM must point at the real helm binary}"
 
-case "${1:-}" in
+# The subcommand isn't necessarily $1: Helm's global flags (--namespace,
+# --kube-context, ...) are valid before it too, e.g. `helm --namespace zammad
+# upgrade ...`. Scan for the first non-flag token, skipping the value of any
+# preceding flag that takes one. Helm's only boolean global flags are --debug
+# and --kube-insecure-skip-tls-verify (see `helm help environment`); every
+# other "-"-prefixed global flag takes a value.
+find_subcommand() {
+  local skip_next=false
+  for arg in "$@"; do
+    if [[ "${skip_next}" == true ]]; then
+      skip_next=false
+      continue
+    fi
+    case "${arg}" in
+    --debug | --kube-insecure-skip-tls-verify | -h | --help)
+      continue
+      ;;
+    -*)
+      [[ "${arg}" == *=* ]] || skip_next=true
+      continue
+      ;;
+    *)
+      echo "${arg}"
+      return
+      ;;
+    esac
+  done
+}
+
+case "$(find_subcommand "$@")" in
 install | upgrade | rollback)
   exec "${REAL_HELM}" "$@"
   ;;

--- a/.github/helm-force-conflicts-wrapper.sh
+++ b/.github/helm-force-conflicts-wrapper.sh
@@ -21,36 +21,7 @@ set -o pipefail
 
 : "${REAL_HELM:?REAL_HELM must point at the real helm binary}"
 
-# The subcommand isn't necessarily $1: Helm's global flags (--namespace,
-# --kube-context, ...) are valid before it too, e.g. `helm --namespace zammad
-# upgrade ...`. Scan for the first non-flag token, skipping the value of any
-# preceding flag that takes one. Helm's only boolean global flags are --debug
-# and --kube-insecure-skip-tls-verify (see `helm help environment`); every
-# other "-"-prefixed global flag takes a value.
-find_subcommand() {
-  local skip_next=false
-  for arg in "$@"; do
-    if [[ "${skip_next}" == true ]]; then
-      skip_next=false
-      continue
-    fi
-    case "${arg}" in
-    --debug | --kube-insecure-skip-tls-verify | -h | --help)
-      continue
-      ;;
-    -*)
-      [[ "${arg}" == *=* ]] || skip_next=true
-      continue
-      ;;
-    *)
-      echo "${arg}"
-      return
-      ;;
-    esac
-  done
-}
-
-case "$(find_subcommand "$@")" in
+case "${1:-}" in
 install | upgrade | rollback)
   exec "${REAL_HELM}" "$@"
   ;;

--- a/.github/helm-force-conflicts-wrapper.sh
+++ b/.github/helm-force-conflicts-wrapper.sh
@@ -21,14 +21,14 @@ set -o pipefail
 set -o nounset
 
 case "${1:-}" in
-  install | upgrade | rollback)
-    exec "${REAL_HELM}" "$@"
-    ;;
-  *)
-    args=()
-    for arg in "$@"; do
-      [[ "${arg}" == "--force-conflicts" ]] || args+=("${arg}")
-    done
-    exec "${REAL_HELM}" "${args[@]}"
-    ;;
+install | upgrade | rollback)
+  exec "${REAL_HELM}" "$@"
+  ;;
+*)
+  args=()
+  for arg in "$@"; do
+    [[ "${arg}" == "--force-conflicts" ]] || args+=("${arg}")
+  done
+  exec "${REAL_HELM}" "${args[@]}"
+  ;;
 esac

--- a/.github/helm-force-conflicts-wrapper.sh
+++ b/.github/helm-force-conflicts-wrapper.sh
@@ -18,7 +18,8 @@
 
 set -o errexit
 set -o pipefail
-set -o nounset
+
+: "${REAL_HELM:?REAL_HELM must point at the real helm binary}"
 
 case "${1:-}" in
 install | upgrade | rollback)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - lint-chart
-      - super-linter
     strategy:
       matrix:
         k8s:
@@ -95,6 +94,11 @@ jobs:
           - v1.33.7
           - v1.34.3
           - v1.35.1
+        ci-values:
+          # One job per zammad/ci/*-values.yaml file, so the default and full
+          # scenarios run in parallel instead of sequentially in the same job.
+          - default
+          - full
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -124,6 +128,14 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0
 
+      - name: Isolate zammad/ci/${{ matrix.ci-values }}-values.yaml
+        # ct has no flag to pick a single ci/*-values.yaml file; it always tests every
+        # one it finds. Removing the other scenario's file here (workspace-only, never
+        # committed) makes ct test only this matrix leg's scenario. --skip-missing-values
+        # below then stops ct from erroring about that file being "removed" relative to
+        # the previous revision, which still has both.
+        run: find zammad/ci -name '*-values.yaml' ! -name '${{ matrix.ci-values }}-values.yaml' -delete
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: if [[ -n "$(ct list-changed --config .github/ct.yaml)" ]]; then echo 'changed=true' >> "$GITHUB_OUTPUT"; fi
@@ -147,8 +159,9 @@ jobs:
         run: kubectl create namespace zammad
 
       - name: Install additional objects for 'full' test scenario
+        if: matrix.ci-values == 'full'
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
       # Use --force-conflicts because of https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing.
       - name: Run chart-testing (install)
-        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'
+        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts' --skip-missing-values

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,4 +138,7 @@ jobs:
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
       - name: Run chart-testing (install)
-        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s'
+        # --force-conflicts: Helm 4 defaults to Server-Side Apply and otherwise errors
+        # when the ECK operator has taken ownership of Elasticsearch CR fields
+        # (e.g. .spec.nodeSets) between the install and the upgrade test.
+        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,13 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: "${{ env.helm-version }}"
+          # Pinned to Helm 3, not env.helm-version: Helm 4 defaults to Server-Side
+          # Apply, which conflicts with fields (e.g. .spec.nodeSets) the ECK operator
+          # takes ownership of after install. ct's --helm-extra-args is passed to every
+          # helm subcommand it runs (install, test, upgrade, uninstall) with no way to
+          # scope it, so a Helm-4-only flag like --force-conflicts can't be added here
+          # without breaking `helm test`/`helm uninstall` (see helm/chart-testing#540).
+          version: "v3.21.4"
 
       - uses: actions/setup-python@v7
         with:
@@ -138,7 +144,4 @@ jobs:
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
       - name: Run chart-testing (install)
-        # --force-conflicts: Helm 4 defaults to Server-Side Apply and otherwise errors
-        # when the ECK operator has taken ownership of Elasticsearch CR fields
-        # (e.g. .spec.nodeSets) between the install and the upgrade test.
-        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'
+        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,7 @@ jobs:
   install-chart:
     name: install-chart
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     needs:
       - kubeconform-chart
     strategy:
@@ -148,6 +149,6 @@ jobs:
       - name: Install additional objects for 'full' test scenario
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
-      # Use --force-testing because of https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing.
+      # Use --force-conflicts because of https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing.
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,12 +108,12 @@ jobs:
 
       - name: Scope --force-conflicts to install/upgrade
         # See .github/helm-force-conflicts-wrapper.sh for why this is needed.
+        env:
+          WRAPPER_DIR: ${{ runner.temp }}/helm-wrapper
         run: |
-          wrapper_dir="${RUNNER_TEMP}/helm-wrapper"
-          mkdir -p "${wrapper_dir}"
-          cp .github/helm-force-conflicts-wrapper.sh "${wrapper_dir}/helm"
-          chmod +x "${wrapper_dir}/helm"
-          echo "${wrapper_dir}" >> "$GITHUB_PATH"
+          mkdir -p "${WRAPPER_DIR}"
+          cp -a .github/helm-force-conflicts-wrapper.sh "${WRAPPER_DIR}/helm"
+          echo "${WRAPPER_DIR}" >> "$GITHUB_PATH"
           echo "REAL_HELM=${{ steps.setup-helm.outputs.helm-path }}" >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,15 +101,46 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
+        id: setup-helm
         uses: azure/setup-helm@v5
         with:
-          # Pinned to Helm 3, not env.helm-version: Helm 4 defaults to Server-Side
-          # Apply, which conflicts with fields (e.g. .spec.nodeSets) the ECK operator
-          # takes ownership of after install. ct's --helm-extra-args is passed to every
-          # helm subcommand it runs (install, test, upgrade, uninstall) with no way to
-          # scope it, so a Helm-4-only flag like --force-conflicts can't be added here
-          # without breaking `helm test`/`helm uninstall` (see helm/chart-testing#540).
-          version: "v3.21.4"
+          version: "${{ env.helm-version }}"
+
+      - name: Scope --force-conflicts to install/upgrade
+        # Helm 4 defaults to Server-Side Apply, which conflicts with fields (e.g.
+        # .spec.nodeSets) the ECK operator takes ownership of after install, so
+        # `helm upgrade` needs --force-conflicts. But ct's --helm-extra-args is
+        # passed to every helm subcommand it runs (install, upgrade, test,
+        # uninstall), and --force-conflicts is only accepted by
+        # install/upgrade/rollback - ct has no way to scope it per subcommand
+        # (helm/chart-testing#540, closed as not_planned). This wrapper shadows
+        # the real `helm` binary and strips --force-conflicts for any subcommand
+        # that doesn't understand it, so it can stay in --helm-extra-args below
+        # without breaking `helm test`/`helm uninstall`. Remove once chart-testing
+        # supports per-subcommand extra args.
+        run: |
+          wrapper_dir="${RUNNER_TEMP}/helm-wrapper"
+          mkdir -p "${wrapper_dir}"
+          cat > "${wrapper_dir}/helm" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          real_helm="REAL_HELM_PATH"
+          case "${1:-}" in
+            install|upgrade|rollback)
+              exec "$real_helm" "$@"
+              ;;
+            *)
+              args=()
+              for a in "$@"; do
+                [[ "$a" == "--force-conflicts" ]] || args+=("$a")
+              done
+              exec "$real_helm" "${args[@]}"
+              ;;
+          esac
+          EOF
+          sed -i "s#REAL_HELM_PATH#${{ steps.setup-helm.outputs.helm-path }}#" "${wrapper_dir}/helm"
+          chmod +x "${wrapper_dir}/helm"
+          echo "${wrapper_dir}" >> "$GITHUB_PATH"
 
       - uses: actions/setup-python@v7
         with:
@@ -144,4 +175,4 @@ jobs:
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
       - name: Run chart-testing (install)
-        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s'
+        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,4 +164,4 @@ jobs:
 
       # Use --force-conflicts because of https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing.
       - name: Run chart-testing (install)
-        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts' --skip-missing-values
+        run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,40 +107,14 @@ jobs:
           version: "${{ env.helm-version }}"
 
       - name: Scope --force-conflicts to install/upgrade
-        # Helm 4 defaults to Server-Side Apply, which conflicts with fields (e.g.
-        # .spec.nodeSets) the ECK operator takes ownership of after install, so
-        # `helm upgrade` needs --force-conflicts. But ct's --helm-extra-args is
-        # passed to every helm subcommand it runs (install, upgrade, test,
-        # uninstall), and --force-conflicts is only accepted by
-        # install/upgrade/rollback - ct has no way to scope it per subcommand
-        # (helm/chart-testing#540, closed as not_planned). This wrapper shadows
-        # the real `helm` binary and strips --force-conflicts for any subcommand
-        # that doesn't understand it, so it can stay in --helm-extra-args below
-        # without breaking `helm test`/`helm uninstall`. Remove once chart-testing
-        # supports per-subcommand extra args.
+        # See .github/helm-force-conflicts-wrapper.sh for why this is needed.
         run: |
           wrapper_dir="${RUNNER_TEMP}/helm-wrapper"
           mkdir -p "${wrapper_dir}"
-          cat > "${wrapper_dir}/helm" <<'EOF'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          real_helm="REAL_HELM_PATH"
-          case "${1:-}" in
-            install|upgrade|rollback)
-              exec "$real_helm" "$@"
-              ;;
-            *)
-              args=()
-              for a in "$@"; do
-                [[ "$a" == "--force-conflicts" ]] || args+=("$a")
-              done
-              exec "$real_helm" "${args[@]}"
-              ;;
-          esac
-          EOF
-          sed -i "s#REAL_HELM_PATH#${{ steps.setup-helm.outputs.helm-path }}#" "${wrapper_dir}/helm"
+          cp .github/helm-force-conflicts-wrapper.sh "${wrapper_dir}/helm"
           chmod +x "${wrapper_dir}/helm"
           echo "${wrapper_dir}" >> "$GITHUB_PATH"
+          echo "REAL_HELM=${{ steps.setup-helm.outputs.helm-path }}" >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@v7
         with:
@@ -174,5 +148,6 @@ jobs:
       - name: Install additional objects for 'full' test scenario
         run: kubectl create --namespace zammad --filename zammad/ci/full-objects.yaml
 
+      # Use --force-testing because of https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing.
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml --helm-extra-args '--timeout 900s --force-conflicts'

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 18.1.0
+version: 18.0.1
 # Just a test comment
 appVersion: 7.1.2-0013
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 19.0.0
+version: 18.1.0
 # Just a test comment
 appVersion: 7.1.2-0013
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: zammad
 version: 18.0.1
-# Just a test comment
 appVersion: 7.1.2-0013
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: zammad
-version: 18.0.0
+version: 19.0.0
+# Just a test comment
 appVersion: 7.1.2-0013
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -254,6 +254,12 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
   The old bitnami PVCs were left behind on uninstall. This is harmless in practice since the
   index rebuilds from PostgreSQL, but if you rely on the volume surviving an uninstall, set
   `elasticsearch.volumeClaimDeletePolicy: DeleteOnScaledownOnly` explicitly.
+- **Helm 4 users:** Helm 4 defaults to Server-Side Apply, and will keep using it for every
+  subsequent `helm upgrade` once a release was installed with it. The ECK operator also manages
+  fields on the `Elasticsearch` resource (e.g. `.spec.nodeSets`) via its own field manager, so a
+  later `helm upgrade` can fail with `Apply failed with 1 conflict: conflict with
+  "elastic-operator" ...`. If you hit this, pass `--force-conflicts` to `helm upgrade` (or
+  `--server-side=false` to opt back into client-side apply for this release).
 
 #### Faster volume permission fixing
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -209,6 +209,12 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 
 ## Upgrading
 
+**Helm 4 users:** the ECK operator manages fields on the `Elasticsearch` resource (e.g.
+`.spec.nodeSets`) via its own field manager, so Helm 4's default Server-Side Apply can make
+`helm upgrade` fail with `Apply failed with 1 conflict: conflict with "elastic-operator" ...`. If
+you hit this, pass `--force-conflicts` to `helm upgrade` - see
+[HIP-0023](https://helm.sh/community/hips/hip-0023/#conflicts-and-forcing).
+
 ### From Chart Version 17.x to 18.0.0
 
 #### Elasticsearch subchart migrated to the ECK operator
@@ -254,12 +260,6 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
   The old bitnami PVCs were left behind on uninstall. This is harmless in practice since the
   index rebuilds from PostgreSQL, but if you rely on the volume surviving an uninstall, set
   `elasticsearch.volumeClaimDeletePolicy: DeleteOnScaledownOnly` explicitly.
-- **Helm 4 users:** Helm 4 defaults to Server-Side Apply, and will keep using it for every
-  subsequent `helm upgrade` once a release was installed with it. The ECK operator also manages
-  fields on the `Elasticsearch` resource (e.g. `.spec.nodeSets`) via its own field manager, so a
-  later `helm upgrade` can fail with `Apply failed with 1 conflict: conflict with "elastic-operator" ...`.
-  If you hit this, pass `--force-conflicts` to `helm upgrade` (or
-  `--server-side=false` to opt back into client-side apply for this release).
 
 #### Faster volume permission fixing
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -257,8 +257,8 @@ and `zammadConfig.cronJob.reindex.schedule` if you want to run it periodically.
 - **Helm 4 users:** Helm 4 defaults to Server-Side Apply, and will keep using it for every
   subsequent `helm upgrade` once a release was installed with it. The ECK operator also manages
   fields on the `Elasticsearch` resource (e.g. `.spec.nodeSets`) via its own field manager, so a
-  later `helm upgrade` can fail with `Apply failed with 1 conflict: conflict with
-  "elastic-operator" ...`. If you hit this, pass `--force-conflicts` to `helm upgrade` (or
+  later `helm upgrade` can fail with `Apply failed with 1 conflict: conflict with "elastic-operator" ...`.
+  If you hit this, pass `--force-conflicts` to `helm upgrade` (or
   `--server-side=false` to opt back into client-side apply for this release).
 
 #### Faster volume permission fixing


### PR DESCRIPTION
#### What this PR does / why we need it

- Reactivate the `upgrade: true` flag for chart-testing to cover upgrade paths.

#### Checklist

- [x] Chart Version bumped
