### PR TITLE
Redis Sentinel: more robust hostname handling + docs

### DIFF
--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 18.1.0
+version: 18.0.4
 appVersion: 7.1.3-0006
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/Chart.yaml
+++ b/zammad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad
-version: 18.0.3
+version: 18.1.0
 appVersion: 7.1.3-0006
 description: Zammad is a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails.
 home: https://zammad.org

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -142,7 +142,7 @@ zammadConfig:
       enabled: true
 ```
 
-`redis.sentinel.enabled` and `redis.architecture=replication` are both required whenever `zammadConfig.redis.sentinel.enabled` is set — the chart fails fast at render time otherwise. The Sentinel hostname is derived automatically from the release name; you don't need to set `zammadConfig.redis.sentinel.sentinels`.
+When bundled Redis is enabled, `redis.sentinel.enabled` and `redis.architecture=replication` are both required whenever `zammadConfig.redis.sentinel.enabled` is set — the chart fails fast at render time otherwise. The Sentinel hostname is derived automatically from the release name; you don't need to set `zammadConfig.redis.sentinel.sentinels`.
 
 To use an **external** Redis/Sentinel setup instead, disable the bundled subchart and point at your own Sentinels:
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -134,7 +134,7 @@ To enable Sentinel with the **bundled** Redis subchart:
 redis:
   sentinel:
     enabled: true
-  architecture: replication  # required: the Sentinel service only exists in this mode
+  architecture: replication # required: the Sentinel service only exists in this mode
 
 zammadConfig:
   redis:
@@ -147,16 +147,14 @@ zammadConfig:
 To use an **external** Redis/Sentinel setup instead, disable the bundled subchart and point at your own Sentinels:
 
 ```yaml
-redis:
-  enabled: false
-
 zammadConfig:
   redis:
+    enabled: false
     sentinel:
       enabled: true
       sentinels:
-      - my-sentinel-1:26379
-      - my-sentinel-2:26379
+        - my-sentinel-1:26379
+        - my-sentinel-2:26379
       masterName: mymaster
 ```
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -142,7 +142,7 @@ zammadConfig:
       enabled: true
 ```
 
-`redis.architecture` must be `replication` whenever `redis.sentinel.enabled` is set — the chart fails fast at render time otherwise. The Sentinel hostname is derived automatically from the release name; you don't need to set `zammadConfig.redis.sentinel.sentinels`.
+`redis.sentinel.enabled` and `redis.architecture=replication` are both required whenever `zammadConfig.redis.sentinel.enabled` is set — the chart fails fast at render time otherwise. The Sentinel hostname is derived automatically from the release name; you don't need to set `zammadConfig.redis.sentinel.sentinels`.
 
 To use an **external** Redis/Sentinel setup instead, disable the bundled subchart and point at your own Sentinels:
 

--- a/zammad/README.md
+++ b/zammad/README.md
@@ -124,6 +124,42 @@ I, [2024-01-24T11:06:14.566513#168-5980]  INFO -- : Moved file dbaa01dd0df3a33bc
 I, [2024-01-24T11:06:14.627896#168-5980]  INFO -- : storage remove '/opt/zammad/storage/fs/e81f/fb09/c5a26/f2081/f93401a/cbe8fff/9983e56c86fccb48d17a2eb1e5900b5b'
 ```
 
+### Redis Sentinel
+
+The chart can talk to Redis through Sentinel instead of a direct connection, either using the bundled Redis subchart or an external Redis/Sentinel setup.
+
+To enable Sentinel with the **bundled** Redis subchart:
+
+```yaml
+redis:
+  sentinel:
+    enabled: true
+  architecture: replication  # required: the Sentinel service only exists in this mode
+
+zammadConfig:
+  redis:
+    sentinel:
+      enabled: true
+```
+
+`redis.architecture` must be `replication` whenever `redis.sentinel.enabled` is set — the chart fails fast at render time otherwise. The Sentinel hostname is derived automatically from the release name; you don't need to set `zammadConfig.redis.sentinel.sentinels`.
+
+To use an **external** Redis/Sentinel setup instead, disable the bundled subchart and point at your own Sentinels:
+
+```yaml
+redis:
+  enabled: false
+
+zammadConfig:
+  redis:
+    sentinel:
+      enabled: true
+      sentinels:
+      - my-sentinel-1:26379
+      - my-sentinel-2:26379
+      masterName: mymaster
+```
+
 ### Deploying on OpenShift
 
 To deploy on OpenShift unprivileged and with [arbitrary UIDs and GIDs](https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids):

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -266,6 +266,9 @@ Redis Variables
 {{- if .Values.zammadConfig.redis.sentinel.enabled }}
 - name: REDIS_SENTINELS
 {{- if .Values.zammadConfig.redis.enabled }}
+{{- if ne .Values.redis.architecture "replication" }}
+{{ fail "zammadConfig.redis.sentinel.enabled requires redis.architecture=replication when the bundled Redis subchart is used (redis.enabled=true); the Sentinel service is only created in replication mode." }}
+{{- end }}
   value: "{{ .Release.Name }}-redis-sentinel:26379"
 {{- else }}
   value: "{{ join "," .Values.zammadConfig.redis.sentinel.sentinels }}"

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -266,8 +266,8 @@ Redis Variables
 {{- if .Values.zammadConfig.redis.sentinel.enabled }}
 - name: REDIS_SENTINELS
 {{- if .Values.zammadConfig.redis.enabled }}
-{{- if ne .Values.redis.architecture "replication" }}
-{{ fail "zammadConfig.redis.sentinel.enabled requires redis.architecture=replication when the bundled Redis subchart is used (redis.enabled=true); the Sentinel service is only created in replication mode." }}
+{{- if not (and .Values.redis.sentinel.enabled (eq .Values.redis.architecture "replication")) }}
+{{ fail "zammadConfig.redis.sentinel.enabled requires redis.sentinel.enabled=true and redis.architecture=replication when the bundled Redis subchart is used (zammadConfig.redis.enabled=true); the Sentinel service is only created in that combination." }}
 {{- end }}
   value: "{{ .Release.Name }}-redis-sentinel:26379"
 {{- else }}

--- a/zammad/templates/_helpers.tpl
+++ b/zammad/templates/_helpers.tpl
@@ -266,7 +266,7 @@ Redis Variables
 {{- if .Values.zammadConfig.redis.sentinel.enabled }}
 - name: REDIS_SENTINELS
 {{- if .Values.zammadConfig.redis.enabled }}
-  value: "{{ .Release.Name }}-redis"
+  value: "{{ .Release.Name }}-redis-sentinel:26379"
 {{- else }}
   value: "{{ join "," .Values.zammadConfig.redis.sentinel.sentinels }}"
 {{- end }}

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -304,9 +304,11 @@ zammadConfig:
     tls: false
 
     sentinel:
-      enabled: false  # set to true to enable Redis Sentinel; requires redis.architecture=replication when redis.enabled=true
-      # only used when redis.enabled=false (external Redis/Sentinel); the bundled subchart's
-      # sentinel service is discovered automatically and does not use this list
+      enabled: false  # set to true to enable Redis Sentinel; with the bundled subchart
+                      # (zammadConfig.redis.enabled=true) this also requires
+                      # redis.sentinel.enabled=true and redis.architecture=replication
+      # only used when zammadConfig.redis.enabled=false (external Redis/Sentinel); the
+      # bundled subchart's sentinel service is discovered automatically and ignores this list
       sentinels:
       - zammad-redis:26379
       masterName: mymaster

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -304,7 +304,9 @@ zammadConfig:
     tls: false
 
     sentinel:
-      enabled: false  # set to true to enable Redis Sentinel
+      enabled: false  # set to true to enable Redis Sentinel; requires redis.architecture=replication when redis.enabled=true
+      # only used when redis.enabled=false (external Redis/Sentinel); the bundled subchart's
+      # sentinel service is discovered automatically and does not use this list
       sentinels:
       - zammad-redis:26379
       masterName: mymaster


### PR DESCRIPTION
## What this PR does / why we need it

Started as a follow-up to #441, which was opened by an external contributor to fix a legitimate-looking bug but never got updated to address CI failures. **Update after review:** @fliebe92 showed that the original premise (the plain `<release>-redis` service can't serve as a Sentinel endpoint) doesn't hold — see the review discussion below. This PR is therefore no longer a bugfix; it's a robustness/clarity improvement plus documentation for a previously undocumented feature.

### Background

#441's actual regression (confirmed) was dropping the `.Release.Name`-based branch for `REDIS_SENTINELS` and replacing it with a static list, which broke installs under any release name other than `zammad` (e.g. `ct install` in CI, which randomizes release names).

#441's stated motivation — that the bundled Redis subchart's plain `-redis` service shouldn't be used as the Sentinel target — turned out to be incorrect: when `sentinel.enabled && architecture == replication`, the subchart's plain `-redis` service *also* exposes port `26379` (`targetPort: sentinel`) via the identical pod selector as the dedicated `-redis-sentinel` service, and is explicitly annotated for Sentinel-based discovery. Zammad's Redis client also defaults a portless entry to `26379`. So `{{ .Release.Name }}-redis` (old, release-name-aware) and `{{ .Release.Name }}-redis-sentinel:26379` (this PR) currently resolve to the same endpoint.

### What this PR actually does

1. **Keeps the release-name-aware `-redis-sentinel:26379` value** — harmless, and more explicit/future-proof than relying on the plain service's incidental Sentinel-port exposure.
2. **Adds a fail-fast guard**: `zammadConfig.redis.sentinel.enabled=true` with the bundled subchart requires `redis.architecture=replication` — that's the only mode in which a Sentinel service exists at all. Previously this misconfiguration would silently produce a Sentinel hostname that resolves to nothing (or, before this PR, to a service without the Sentinel port), surfacing only as a hung rollout.
3. **Documents Redis Sentinel in the README** (bundled and external setups) — this was completely undocumented before, which is arguably the more valuable fix for the confusion behind #441.
4. Chart version bump corrected to a patch release (`18.0.4`), matching existing versioning conventions.

## Checklist

- [x] Chart Version bumped (18.0.3 → 18.0.4)
- [x] Upgrading instructions — not needed, no breaking change; new fail-fast guard only rejects an already-broken configuration

## Test plan

- [x] `helm template` with a randomized release name (mirroring `ct install`) confirms `REDIS_SENTINELS` matches the actually-created `<release>-redis-sentinel` service
- [x] `helm template` with `redis.enabled=false` confirms the external-Redis static `sentinels` list is unaffected
- [x] `helm template` with `sentinel.enabled=true` and default `architecture=standalone` now fails fast with a clear error instead of hanging
- [x] `helm lint` passes
- [x] CI (`ct install` with `full-values.yaml`, Sentinel + replication) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation requiring replication architecture when bundled Redis Sentinel is enabled.
  - Preserved the existing Sentinel endpoint and support for externally managed Redis and Sentinel configurations.

- **Documentation**
  - Clarified bundled and external Sentinel setup, required settings, and automatic service discovery.
  - Updated examples for disabling bundled Redis and specifying external Sentinel instances.

- **Chores**
  - Updated the Helm chart version to 18.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->