### PR TITLE
Maintenance: update CI testing matrix

### DIFF
--- a/.github/updatecli.yaml
+++ b/.github/updatecli.yaml
@@ -82,6 +82,13 @@ sources:
       url: https://github.com/yannh/kubeconform.git
       versionfilter:
         kind: semver
+  kind-version:
+    name: kind-version
+    kind: gittag
+    spec:
+      url: https://github.com/kubernetes-sigs/kind.git
+      versionfilter:
+        kind: semver
 
 conditions: {}
 
@@ -199,6 +206,16 @@ targets:
     spec:
       file: .github/workflows/ci.yaml
       key: "$.env.kubeconform-version"
+  kind-version-ci:
+    name: kind-version
+    kind: yaml
+    sourceid: kind-version
+    # {{ if .github.enabled }}
+    scmid: zammad-helm
+    # {{ end }}
+    spec:
+      file: .github/workflows/ci.yaml
+      key: "$.env.kind-version"
 # {{ if .github.enabled }}
 scms:
   zammad-helm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
 env:
   helm-version: v4.2.4
   kubeconform-version: v0.8.0
+  kind-version: v0.33.0
 
 jobs:
   super-linter:
@@ -147,6 +148,10 @@ jobs:
         with:
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
+          # Kubernetes 1.37+ node images dropped the kubeadm v1beta3 config
+          # format that older kind releases emit; kind needs to be at least
+          # as new as the newest node image tested above.
+          version: "${{ env.kind-version }}"
 
       - name: Install ECK operator (CRDs + operator)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
     strategy:
       matrix:
         k8s:
+          # kubernetes releases
           - v1.35.8
           - v1.36.4
           - v1.37.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,9 +61,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.34.8
-          - v1.35.5
-          - v1.36.1
+          - v1.35.8
+          - v1.36.4
+          - v1.37.0
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -91,9 +91,9 @@ jobs:
       matrix:
         k8s:
           # Versions of kindest/node
-          - v1.33.7
-          - v1.34.3
-          - v1.35.1
+          - v1.35.8
+          - v1.36.4
+          - v1.37.0
         ci-values:
           # One job per zammad/ci/*-values.yaml file, so the default and full
           # scenarios run in parallel instead of sequentially in the same job.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,9 @@ jobs:
           # format that older kind releases emit; kind needs to be at least
           # as new as the newest node image tested above.
           version: "${{ env.kind-version }}"
+          # Keep the kubectl client used by later steps within kubectl's
+          # supported +/-1 minor version skew of the cluster's API server.
+          kubectl_version: ${{ matrix.k8s }}
 
       - name: Install ECK operator (CRDs + operator)
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Kubernetes compatibility checks to cover versions 1.35.8, 1.36.4, and 1.37.0.
  * Updated kind-based test environments and kubectl versions to match the selected Kubernetes releases.
  * Retired testing coverage for older Kubernetes releases.

* **Chores**
  * Added automated tracking and synchronization for the kind version used in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->