### PR TITLE
Drop redundant kind-version pin now that kind-action defaults to it

### DIFF
--- a/.github/updatecli.yaml
+++ b/.github/updatecli.yaml
@@ -82,13 +82,6 @@ sources:
       url: https://github.com/yannh/kubeconform.git
       versionfilter:
         kind: semver
-  kind-version:
-    name: kind-version
-    kind: gittag
-    spec:
-      url: https://github.com/kubernetes-sigs/kind.git
-      versionfilter:
-        kind: semver
 
 conditions: {}
 
@@ -206,16 +199,6 @@ targets:
     spec:
       file: .github/workflows/ci.yaml
       key: "$.env.kubeconform-version"
-  kind-version-ci:
-    name: kind-version
-    kind: yaml
-    sourceid: kind-version
-    # {{ if .github.enabled }}
-    scmid: zammad-helm
-    # {{ end }}
-    spec:
-      file: .github/workflows/ci.yaml
-      key: "$.env.kind-version"
 # {{ if .github.enabled }}
 scms:
   zammad-helm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
 env:
   helm-version: v4.2.4
   kubeconform-version: v0.8.0
-  kind-version: v0.33.0
 
 jobs:
   super-linter:
@@ -148,10 +147,6 @@ jobs:
         with:
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
-          # Kubernetes 1.37+ node images dropped the kubeadm v1beta3 config
-          # format that older kind releases emit; kind needs to be at least
-          # as new as the newest node image tested above.
-          version: "${{ env.kind-version }}"
           # Keep the kubectl client used by later steps within kubectl's
           # supported +/-1 minor version skew of the cluster's API server.
           kubectl_version: ${{ matrix.k8s }}


### PR DESCRIPTION
## Summary
* #466 pinned `kind-version: v0.33.0` (and the matching `version:` input on `helm/kind-action`) to fix Kubernetes 1.37 node images, which need kind's v1beta4 kubeadm config support.
* #467 bumped `helm/kind-action` to v1.15.0, which now defaults its `version` input to `v0.33.0` too - making our pin exactly redundant.
* This removes the now-duplicate `kind-version` env var, workflow input override, and `updatecli.yaml` source/target, relying instead on `kind-action`'s own default (kept current via the existing dependabot config).
* `kubectl_version: ${{ matrix.k8s }}` is kept: `kind-action` v1.15.0's new default (a hardcoded `v1.37.0`) would violate kubectl's +/-1 minor version skew policy against the `v1.35.8` matrix leg.

## Test plan
- [ ] CI passes on all `install-chart` matrix legs (v1.35.8, v1.36.4, v1.37.0)
- [x] Verified locally with `updatecli pipeline diff --config .github/updatecli.yaml` that no config references `kind-version` and the pipeline still runs cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed automated Kind version update management.
  - CI now uses the default Kind version provided by the setup action.
  - Existing node image and kubectl version settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->